### PR TITLE
put php in environment path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ binaries/trusty/*
 *.pyc
 *.swp
 env
+.idea
+*.iml

--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -199,23 +199,26 @@ class ComposerTool(object):
                            delim='@')
         # Run from /tmp/staged/app
         try:
-            phpPath = os.path.join(self._ctx['BUILD_DIR'], 'php', 'bin', 'php')
+            phpDir = os.path.join(self._ctx['BUILD_DIR'], 'php')
+            phpBinDir = os.path.join(phpDir, 'bin')
+            phpPath = os.path.join(phpBinDir, 'php')
             phpCfg = os.path.join(self._ctx['TMPDIR'], 'php.ini')
-            composerPath = os.path.join(self._ctx['BUILD_DIR'], 'php',
-                                        'bin', 'composer.phar')
+            composerPath = os.path.join(phpBinDir, 'composer.phar')
+
             composerEnv = {
-                'LD_LIBRARY_PATH': os.path.join(self._ctx['BUILD_DIR'],
-                                                'php', 'lib'),
+                'PATH': os.getenv('PATH') + os.pathsep + phpBinDir,
+                'LD_LIBRARY_PATH': os.path.join(phpDir, 'lib'),
                 'HOME': self._ctx['BUILD_DIR'],
                 'COMPOSER_VENDOR_DIR': self._ctx['COMPOSER_VENDOR_DIR'],
                 'COMPOSER_BIN_DIR': self._ctx['COMPOSER_BIN_DIR'],
                 'COMPOSER_CACHE_DIR': self._ctx['COMPOSER_CACHE_DIR']
             }
+
             composerCmd = [phpPath,
                            '-c "%s"' % phpCfg,
                            composerPath,
                            'install',
-                           '--no-progress']
+                           '--no-progress', '--no-ansi']
             composerCmd.extend(self._ctx['COMPOSER_INSTALL_OPTIONS'])
             self._log.debug("Running [%s]", ' '.join(composerCmd))
             output = stream_output(sys.stdout,
@@ -224,8 +227,8 @@ class ComposerTool(object):
                                    cwd=self._ctx['BUILD_DIR'],
                                    shell=True)
             _log.debug('composer output [%s]', output)
-        except Exception:
-            _log.error("Command Failed: %s")
+        except Exception as e:
+            _log.error("Composer failed: %s" % e)
 
 
 # Extension Methods

--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -191,9 +191,13 @@ class ComposerTool(object):
         (self._builder.copy()
             .under('{BUILD_DIR}/php/etc')
             .where_name_is('php.ini')
-            .into('TMPDIR')
+            .into('{TMPDIR}/php/etc')
          .done())
-        utils.rewrite_cfgs(os.path.join(self._ctx['TMPDIR'], 'php.ini'),
+
+        phpCfgDir = os.path.join(self._ctx['TMPDIR'], 'php', 'etc')
+        phpCfg = os.path.join(phpCfgDir, 'php.ini')
+
+        utils.rewrite_cfgs(os.path.join(self._ctx['TMPDIR'], 'php', 'etc', 'php.ini'),
                            {'TMPDIR': self._ctx['TMPDIR'],
                             'HOME': self._ctx['BUILD_DIR']},
                            delim='@')
@@ -202,11 +206,11 @@ class ComposerTool(object):
             phpDir = os.path.join(self._ctx['BUILD_DIR'], 'php')
             phpBinDir = os.path.join(phpDir, 'bin')
             phpPath = os.path.join(phpBinDir, 'php')
-            phpCfg = os.path.join(self._ctx['TMPDIR'], 'php.ini')
             composerPath = os.path.join(phpBinDir, 'composer.phar')
 
             composerEnv = {
                 'PATH': os.getenv('PATH') + os.pathsep + phpBinDir,
+                'PHPRC': phpCfgDir,
                 'LD_LIBRARY_PATH': os.path.join(phpDir, 'lib'),
                 'HOME': self._ctx['BUILD_DIR'],
                 'COMPOSER_VENDOR_DIR': self._ctx['COMPOSER_VENDOR_DIR'],

--- a/lib/php/extension.py
+++ b/lib/php/extension.py
@@ -59,7 +59,8 @@ def service_commands(ctx):
 def service_environment(ctx):
     env = {
         'LD_LIBRARY_PATH': '@LD_LIBRARY_PATH:@HOME/php/lib',
-        'PATH': '@PATH:@HOME/php/bin'
+        'PATH': '@PATH:@HOME/php/bin',
+        'PHPRC': '@HOME/php/etc'
     }
     if 'snmp' in ctx['PHP_EXTENSIONS']:
         env['MIBDIRS'] = '@HOME/php/mibs'

--- a/lib/php/extension.py
+++ b/lib/php/extension.py
@@ -58,7 +58,8 @@ def service_commands(ctx):
 
 def service_environment(ctx):
     env = {
-        'LD_LIBRARY_PATH': '@LD_LIBRARY_PATH:@HOME/php/lib'
+        'LD_LIBRARY_PATH': '@LD_LIBRARY_PATH:@HOME/php/lib',
+        'PATH': '@PATH:@HOME/php/bin'
     }
     if 'snmp' in ctx['PHP_EXTENSIONS']:
         env['MIBDIRS'] = '@HOME/php/mibs'


### PR DESCRIPTION
Adds PHP to the runtime and composer environment paths. Closes #26 