### PR TITLE
set LD_LIBRARY_PATH correctly when PHP_VM=hhvm in composer

### DIFF
--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -156,6 +156,9 @@ class ComposerExtension(ExtensionHelper):
     def binary_path(self):
         return self.composer_strategy.binary_path()
 
+    def ld_library_path(self):
+        return self.composer_strategy.ld_library_path()
+
     def _compile(self, install):
         self._builder = install.builder
         self.move_local_vendor_folder()
@@ -211,8 +214,7 @@ class ComposerExtension(ExtensionHelper):
             composerPath = os.path.join(self._ctx['BUILD_DIR'], 'php',
                                         'bin', 'composer.phar')
             composerEnv = {
-                'LD_LIBRARY_PATH': os.path.join(self._ctx['BUILD_DIR'],
-                                                'php', 'lib'),
+                'LD_LIBRARY_PATH': self.ld_library_path(),
                 'HOME': self._ctx['BUILD_DIR'],
                 'COMPOSER_VENDOR_DIR': self._ctx['COMPOSER_VENDOR_DIR'],
                 'COMPOSER_BIN_DIR': self._ctx['COMPOSER_BIN_DIR'],
@@ -246,6 +248,10 @@ class HHVMComposerStrategy(object):
     def write_config(self, builder):
         pass
 
+    def ld_library_path(self):
+        return os.path.join(
+            self._ctx['BUILD_DIR'], 'hhvm', 'usr', 'lib', 'hhvm')
+
 
 class PHPComposerStrategy(object):
     def __init__(self, ctx):
@@ -266,6 +272,11 @@ class PHPComposerStrategy(object):
                            {'TMPDIR': self._ctx['TMPDIR'],
                             'HOME': self._ctx['BUILD_DIR']},
                            delim='@')
+
+    def ld_library_path(self):
+        return os.path.join(
+            self._ctx['BUILD_DIR'], 'php', 'lib')
+
 
 
 # Extension Methods

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -470,3 +470,21 @@ class TestComposer(object):
         ct = self.ct.ComposerExtension(ctx)
         path = ct.binary_path()
         eq_('/usr/awesome/php/bin/php', path)
+
+    def test_ld_library_path_for_hhvm(self):
+        ctx = utils.FormattedDict({
+            'BUILD_DIR': '/usr/awesome/',
+            'PHP_VM': 'hhvm'
+        })
+        ct = self.ct.ComposerExtension(ctx)
+        path = ct.ld_library_path()
+        eq_('/usr/awesome/hhvm/usr/lib/hhvm', path)
+
+    def test_ld_library_path_for_php(self):
+        ctx = utils.FormattedDict({
+            'BUILD_DIR': '/usr/awesome',
+            'PHP_VM': 'php'
+        })
+        ct = self.ct.ComposerExtension(ctx)
+        path = ct.ld_library_path()
+        eq_('/usr/awesome/php/lib', path)


### PR DESCRIPTION
LD_LIBRARY_PATH was set to php/lib when using HHVM instead of PHP, this patch sets it to
hhvm/usr/lib/hhvm/

Otherwise it complains about not found libraries and won't even run