### PR TITLE
Move lib/vendor to vendor and document COMPOSER_VENDOR_DIR

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -33,6 +33,7 @@ Here are a list of the options that an application developer might want to overr
 | HTTP_PROXY | Instruct the build pack to use an HTTP proxy to download resources accessed via http. |
 | HTTPS_PROXY | Instruct the build pack to use an HTTP proxy to download resources accessed via https. |
 | ADDITIONAL_PREPROCESS_CMDS | A list of additional commands that should be run prior to the application.  This allows developers a way to run things like migration scripts prior to the application being run. |
+| COMPOSER_VENDOR_DIR | Location of `vendor` directory that is created by composer upon staging. |
 
 ### HTTPD, Nginx and PHP configuration
 

--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -144,7 +144,7 @@ class ComposerExtension(ExtensionHelper):
             'COMPOSER_HASH_URL': '{DOWNLOAD_URL}/composer/{COMPOSER_VERSION}/'
                                  '{COMPOSER_PACKAGE}.{CACHE_HASH_ALGORITHM}',
             'COMPOSER_INSTALL_OPTIONS': ['--no-interaction', '--no-dev'],
-            'COMPOSER_VENDOR_DIR': '{BUILD_DIR}/{LIBDIR}/vendor',
+            'COMPOSER_VENDOR_DIR': '{BUILD_DIR}/vendor',
             'COMPOSER_BIN_DIR': '{BUILD_DIR}/php/bin',
             'COMPOSER_CACHE_DIR': '{CACHE_DIR}/composer'
         }

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -520,7 +520,7 @@ class TestComposer(object):
             'LIBDIR': 'lib'
         })
         ct = self.extension_module.ComposerExtension(ctx)
-        eq_('/tmp/build/lib/vendor', ct._ctx['COMPOSER_VENDOR_DIR'])
+        eq_('/tmp/build/vendor', ct._ctx['COMPOSER_VENDOR_DIR'])
         eq_('/tmp/build/php/bin', ct._ctx['COMPOSER_BIN_DIR'])
         eq_('/tmp/cache/composer', ct._ctx['COMPOSER_CACHE_DIR'])
 


### PR DESCRIPTION
When I run my application locally, the `vendor` directory is created alongside `composer.json`, this is the default behaviour of composer.phar. I expected the build pack to reproduce this behaviour, .but the default setting for this build pack is to create `lib/vendor` instead of just `vendor`.

I fixed this problem for my setup by overriding `COMPOSER_VENDOR_DIR` in `.bp-config/options.json`, but I think it makes sense to have local setups and deployed setups as similar as possible, hence the pull request.

`COMPOSER_VENDOR_DIR` was not documented, so I added documentation for it.