### PR TITLE
Fix php5.6 specified in composer.json

### DIFF
--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -89,9 +89,13 @@ class ComposerConfiguration(object):
             selected = self._ctx['PHP_54_LATEST']
         elif requested == '5.5.*' or requested == '>=5.5':
             selected = self._ctx['PHP_55_LATEST']
+        elif requested == '5.6.*' or requested == '>=5.6':
+            selected = self._ctx['PHP_56_LATEST']
         elif requested.startswith('5.4.'):
             selected = requested
         elif requested.startswith('5.5.'):
+            selected = requested
+        elif requested.startswith('5.6.'):
             selected = requested
         else:
             selected = self._ctx['PHP_VERSION']

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -453,7 +453,8 @@ class TestComposer(object):
             'PHP_VERSION': '5.4.31',
             'PHP_54_LATEST': '5.4.31',
             'BUILD_DIR': '',
-            'PHP_55_LATEST': '5.5.15'
+            'PHP_55_LATEST': '5.5.15',
+            'PHP_56_LATEST': '5.6.7'
         }
         pick_php_version = \
             self.extension_module.ComposerConfiguration(ctx).pick_php_version
@@ -473,6 +474,12 @@ class TestComposer(object):
         # exact PHP 5.5 versions
         eq_('5.5.15', pick_php_version('5.5.15'))
         eq_('5.5.14', pick_php_version('5.5.14'))
+        # latest PHP 5.6 version
+        eq_('5.6.7', pick_php_version('>=5.6'))
+        eq_('5.6.7', pick_php_version('5.6.*'))
+        # exact PHP 5.6 versions
+        eq_('5.6.7', pick_php_version('5.6.7'))
+        eq_('5.6.6', pick_php_version('5.6.6'))
         # not understood, should default to PHP_VERSION
         eq_('5.4.31', pick_php_version(''))
         eq_('5.4.31', pick_php_version(None))


### PR DESCRIPTION
This is a quick and dirty fix for #59. It's just a band-aid that doesn't really address the underlying issues in that it only adds some new versions.

The code for parsing versions should probably take semver into account and not just contain a list of versions. PHP-7 is also on the horizon so it might be time to think about making this future proof.

