### PR TITLE
Detect and configure a persistent session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Here are some special features of the buildpack.
   - Supports an extension mechanism that allows the buildpack to provide additional functionality.
   - Allows for application developers to provide custom extensions.
   - Easy troubleshooting with the `BP_DEBUG` environment variable.
+  - Download location is configurable, allowing users to host binaries on the same network (i.e. run without an Internet connection)
+  - Smart session storage, defaults to file w/sticky sessions but can also use redis or memcached for storage.
 
 ## Examples
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,40 @@
+## Sessions
+
+When your application has one instance, it's mostly safe to use the default session storage, which is the local file system.  You would only see problems if your single instance crashes as the local file system would go away and you'd lose your sessions.  For many applications, this will work just fine but please consider how this will impact your application.
+
+If you have multiple application instances or you need a more robust solution for your application, then you'll want to use Redis or Memcached as a backing store for your session data.  The build pack supports both and when one is bound to your application it will detected it and automatically configure PHP to use it for session storage.
+
+### Usage
+
+By default, there's no configuration necessary.  Simple create a Redis or Memcached service, make sure the service name contains `redis-sessions` or `memcached-sessions` and then bind the service to the application.
+
+Ex:
+
+```
+cf create-service redis some-plan app-redis-sessions
+cf bind-service app app-redis-sessions
+cf restage app
+```
+
+If you want to use a specific service instance or change the search key, you can do that by setting either `REDIS_SESSION_STORE_SERVICE_NAME` or `MEMCACHED_SESSION_STORE_SERVICE_NAME` in `.bp-config/options.json` to the new search key.  The session configuration extension will then search the bound services by name for the new session key.
+
+### Configuration Changes
+
+When detected, the following changes will be made.
+
+#### Redis
+
+  - the `redis` PHP extension will be installed, which provides the session save handler
+  - `session.name` will be set to `PHPSESSIONID` this disables sticky sessions
+  - `session.save_handler` is configured to `redis`
+  - `session.save_path` is configured based on the bound credentials (i.e. `tcp://host:port?auth=pass`)
+
+#### Memcached
+
+ - the `memcached` PHP extension will be installed, which provides the session save handler
+ - `session.name` will be set to `PHPSESSIONID` this disables sticky sessions
+ - `session.save_handler` is configured to `memcached`
+ - `session.save_path` is configured based on the bound credentials (i.e. `PERSISTENT=app_sessions host:port`)
+ - `memcached.sess_binary` is set to `On`
+ - `memcached.use_sasl` is set to `On`, which enables authentication
+ - `memcached.sess_sasl_username` and `memcached.sess_sasl_password` are set with the service credentials.

--- a/extensions/sessions/extension.py
+++ b/extensions/sessions/extension.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Session Config Extension
+
+Configures redis or memcached for session sharing
+"""
+from extension_helpers import PHPExtensionHelper
+
+
+class BaseSetup(object):
+    def __init__(self, ctx, info):
+        self._ctx = ctx
+        self._info = info
+        self.creds = self._info.get('credentials', {})
+
+    def session_store_key(self):
+        key_name = self.DEFAULT_SESSION_STORE_TRIGGER
+        if self.CUSTOM_SESSION_STORE_KEY_NAME in self._ctx:
+            key_name = self._ctx[self.CUSTOM_SESSION_STORE_KEY_NAME]
+        return key_name
+
+    def custom_config_php_ini(self, php_ini):
+        pass
+
+
+class RedisSetup(BaseSetup):
+    DEFAULT_SESSION_STORE_TRIGGER = 'redis-sessions'
+    CUSTOM_SESSION_STORE_KEY_NAME = 'REDIS_SESSION_STORE_SERVICE_NAME'
+    EXTENSION_NAME = 'redis'
+
+    def __init__(self, ctx, info):
+        BaseSetup.__init__(self, ctx, info)
+
+    def session_save_path(self):
+        return "tcp://%s:%s?auth=%s" % (
+            self.creds.get('hostname',
+                           self.creds.get('host', 'not-found')),
+            self.creds.get('port', 'not-found'),
+            self.creds.get('password', ''))
+
+
+class MemcachedSetup(BaseSetup):
+    DEFAULT_SESSION_STORE_TRIGGER = 'memcached-sessions'
+    CUSTOM_SESSION_STORE_KEY_NAME = 'MEMCACHED_SESSION_STORE_SERVICE_NAME'
+    EXTENSION_NAME = 'memcached'
+
+    def __init__(self, ctx, info):
+        BaseSetup.__init__(self, ctx, info)
+
+    def session_save_path(self):
+        return 'PERSISTENT=app_sessions %s' % self.creds.get('servers',
+                                                             'not-found')
+
+    def custom_config_php_ini(self, php_ini):
+        php_ini.append_lines([
+            'memcached.sess_binary=On\n',
+            'memcached.use_sasl=On\n',
+            'memcached.sess_sasl_username=%s\n' % self.creds.get('username',
+                                                                 ''),
+            'memcached.sess_sasl_password=%s\n' % self.creds.get('password', '')
+        ])
+
+
+class SessionStoreConfig(PHPExtensionHelper):
+    def __init__(self, ctx):
+        PHPExtensionHelper.__init__(self, ctx)
+        self.service = None
+
+    def _should_compile(self):
+        if self.service is None:
+            self.service = self._load_session()
+        return self.service is not None
+
+    def _load_session(self):
+        # load search keys
+        session_types = [
+            RedisSetup,
+            MemcachedSetup
+        ]
+        # search for an appropriately name session store
+        vcap_services = self._ctx.get('VCAP_SERVICES', {})
+        for provider, services in vcap_services.iteritems():
+            for service in services:
+                service_name = service.get('name', '')
+                for session_type in session_types:
+                    session = session_type(self._ctx, service)
+                    if service_name.find(session.session_store_key()) != -1:
+                        return session
+
+    def _configure(self):
+        # load the PHP extension that provides session save handler
+        if self.service is not None:
+            self._ctx.get('PHP_EXTENSIONS',
+                          []).append(self.service.EXTENSION_NAME)
+
+    def _compile(self, install):
+        # modify php.ini to contain the right session config
+        self.load_config()
+        self._php_ini.update_lines(
+            '^session\.name = JSESSIONID$',
+            'session.name = PHPSESSIONID')
+        self._php_ini.update_lines(
+            '^session\.save_handler = files$',
+            'session.save_handler = %s' % self.service.EXTENSION_NAME)
+        self._php_ini.update_lines(
+            '^session\.save_path = "@{TMPDIR}"$',
+            'session.save_path = "%s"' % self.service.session_save_path())
+        self.service.custom_config_php_ini(self._php_ini)
+        self._php_ini.save(self._php_ini_path)
+
+
+SessionStoreConfig.register(__name__)

--- a/tests/data/sessions/vcap_services_alt_name.json
+++ b/tests/data/sessions/vcap_services_alt_name.json
@@ -1,0 +1,51 @@
+{
+ "VCAP_SERVICES": {
+  "newrelic": [
+   {
+    "credentials": {
+     "licenseKey": "newrelic-key"
+    },
+    "label": "newrelic",
+    "name": "newrelic",
+    "plan": "standard",
+    "tags": [
+     "Monitoring"
+    ]
+   }
+  ],
+  "redis": [
+   {
+    "credentials": {
+     "host": "redis-host",
+     "password": "redis-pass",
+     "port": 45629
+    },
+    "label": "redis",
+    "name": "php-session-db",
+    "plan": "shared-vm",
+    "tags": [
+     "pivotal",
+     "redis"
+    ]
+   }
+  ],
+  "sendgrid": [
+   {
+    "credentials": {
+     "hostname": "smtp.sendgrid.net",
+     "password": "sendgrid-pass",
+     "username": "sendgrid-user"
+    },
+    "label": "sendgrid",
+    "name": "sendgrid",
+    "plan": "free",
+    "tags": [
+     "Retail",
+     "Email",
+     "smtp",
+     "Inventory management"
+    ]
+   }
+  ]
+ }
+}

--- a/tests/data/sessions/vcap_services_memcached.json
+++ b/tests/data/sessions/vcap_services_memcached.json
@@ -1,0 +1,54 @@
+{
+ "VCAP_SERVICES": {
+  "newrelic": [
+   {
+    "credentials": {
+     "licenseKey": "newrelic-key"
+    },
+    "label": "newrelic",
+    "name": "newrelic",
+    "plan": "standard",
+    "tags": [
+     "Monitoring"
+    ]
+   }
+  ],
+  "memcachedcloud": [
+   {
+    "credentials": {
+     "password": "password",
+     "servers": "host:port",
+     "username": "username"
+    },
+    "label": "memcachedcloud",
+    "name": "my-memcached-sessions",
+    "plan": "30mb",
+    "tags": [
+     "Data Stores",
+     "Data Store",
+     "Caching",
+     "key-value",
+     "caching"
+    ]
+   }
+  ],
+  "sendgrid": [
+   {
+    "credentials": {
+     "hostname": "smtp.sendgrid.net",
+     "password": "sendgrid-pass",
+     "username": "sendgrid-user"
+    },
+    "label": "sendgrid",
+    "name": "sendgrid",
+    "plan": "free",
+    "tags": [
+     "Retail",
+     "Email",
+     "smtp",
+     "Inventory management"
+    ]
+   }
+  ]
+ }
+}

--- a/tests/data/sessions/vcap_services_redis.json
+++ b/tests/data/sessions/vcap_services_redis.json
@@ -1,0 +1,51 @@
+{
+ "VCAP_SERVICES": {
+  "newrelic": [
+   {
+    "credentials": {
+     "licenseKey": "newrelic-key"
+    },
+    "label": "newrelic",
+    "name": "newrelic",
+    "plan": "standard",
+    "tags": [
+     "Monitoring"
+    ]
+   }
+  ],
+  "redis": [
+   {
+    "credentials": {
+     "host": "redis-host",
+     "password": "redis-pass",
+     "port": 45629
+    },
+    "label": "redis",
+    "name": "redis-sessions",
+    "plan": "shared-vm",
+    "tags": [
+     "pivotal",
+     "redis"
+    ]
+   }
+  ],
+  "sendgrid": [
+   {
+    "credentials": {
+     "hostname": "smtp.sendgrid.net",
+     "password": "sendgrid-pass",
+     "username": "sendgrid-user"
+    },
+    "label": "sendgrid",
+    "name": "sendgrid",
+    "plan": "free",
+    "tags": [
+     "Retail",
+     "Email",
+     "smtp",
+     "Inventory management"
+    ]
+   }
+  ]
+ }
+}

--- a/tests/data/sessions/vcap_services_with_redis_not_for_sessions.json
+++ b/tests/data/sessions/vcap_services_with_redis_not_for_sessions.json
@@ -1,0 +1,52 @@
+{
+ "VCAP_SERVICES": {
+  "newrelic": [
+   {
+    "credentials": {
+     "licenseKey": "newrelic-key"
+    },
+    "label": "newrelic",
+    "name": "newrelic",
+    "plan": "standard",
+    "tags": [
+     "Monitoring"
+    ]
+   }
+  ],
+  "redis": [
+   {
+    "credentials": {
+     "host": "redis-host",
+     "password": "redis-pass",
+     "port": 45629
+    },
+    "label": "redis",
+    "name": "p-redis-db",
+    "plan": "shared-vm",
+    "tags": [
+     "pivotal",
+     "redis"
+    ]
+   }
+  ],
+  "sendgrid": [
+   {
+    "credentials": {
+     "hostname": "smtp.sendgrid.net",
+     "password": "sendgrid-pass",
+     "username": "sendgrid-user"
+    },
+    "label": "sendgrid",
+    "name": "sendgrid",
+    "plan": "free",
+    "tags": [
+     "Retail",
+     "Email",
+     "smtp",
+     "Inventory management"
+    ]
+   }
+  ]
+ }
+}
+

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,131 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from dingus import Dingus
+from nose.tools import eq_
+from build_pack_utils import utils
+
+
+class TestSessions(object):
+
+    def __init__(self):
+        self.extension_module = utils.load_extension('extensions/sessions')
+
+    def test_load_session_name_contains_redis(self):
+        ctx = json.load(open('tests/data/sessions/vcap_services_redis.json'))
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        eq_(self.extension_module.RedisSetup, type(sessions._load_session()))
+
+    def test_load_session_name_contains_memcached(self):
+        ctx = json.load(
+            open('tests/data/sessions/vcap_services_memcached.json'))
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        eq_(self.extension_module.MemcachedSetup,
+            type(sessions._load_session()))
+
+    def test_load_session_no_service(self):
+        sessions = self.extension_module.SessionStoreConfig({})
+        eq_(None, sessions._load_session())
+
+    def test_alt_name_logic_redis(self):
+        redis = self.extension_module.RedisSetup({}, {})
+        eq_('redis-sessions', redis.session_store_key())
+        redis = self.extension_module.RedisSetup({
+            'REDIS_SESSION_STORE_SERVICE_NAME': 'my-redis-db'
+        }, {})
+        eq_('my-redis-db', redis.session_store_key())
+
+    def test_alt_name_logic_memcached(self):
+        memcached = self.extension_module.MemcachedSetup({}, {})
+        eq_('memcached-sessions', memcached.session_store_key())
+        memcached = self.extension_module.MemcachedSetup({
+            'MEMCACHED_SESSION_STORE_SERVICE_NAME': 'my-memcached-db'
+        }, {})
+        eq_('my-memcached-db', memcached.session_store_key())
+
+    def test_load_session_alt_name(self):
+        ctx = json.load(
+            open('tests/data/sessions/vcap_services_alt_name.json'))
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        eq_(None, sessions._load_session())
+        ctx['REDIS_SESSION_STORE_SERVICE_NAME'] = 'php-session-db'
+        eq_(self.extension_module.RedisSetup, type(sessions._load_session()))
+
+    def test_should_compile(self):
+        sessions = self.extension_module.SessionStoreConfig({})
+        sessions._load_session = Dingus(return_value=object())
+        eq_(True, sessions._should_compile())
+
+    def test_load_session_redis_but_not_for_sessions(self):
+        ctx = json.load(open('tests/data/sessions/'
+                             'vcap_services_with_redis_not_for_sessions.json'))
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        eq_(None, sessions._load_session())
+
+    def test_configure_adds_redis_extension(self):
+        ctx = json.load(open('tests/data/sessions/vcap_services_redis.json'))
+        ctx['PHP_EXTENSIONS'] = []
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        sessions._php_ini = Dingus()
+        sessions.configure()
+        eq_(True, 'redis' in ctx['PHP_EXTENSIONS'])
+
+    def test_configure_adds_memcached_extension(self):
+        ctx = json.load(
+            open('tests/data/sessions/vcap_services_memcached.json'))
+        ctx['PHP_EXTENSIONS'] = []
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        sessions._php_ini = Dingus()
+        sessions.configure()
+        eq_(True, 'memcached' in ctx['PHP_EXTENSIONS'])
+
+    def test_configure_adds_redis_config_to_php_ini(self):
+        ctx = json.load(open('tests/data/sessions/vcap_services_redis.json'))
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        sessions.load_config = Dingus()
+        php_ini = Dingus()
+        sessions._php_ini = php_ini
+        sessions._php_ini_path = '/tmp/staged/app/php/etc/php.ini'
+        sessions.compile(None)
+        eq_(1, len(sessions.load_config.calls()))
+        eq_(3, len(php_ini.update_lines.calls()))
+        eq_(1, len(php_ini.save.calls()))
+        eq_(4, len(php_ini.calls()))
+        eq_('session.save_handler = redis',
+            php_ini.update_lines.calls()[1].args[1])
+        eq_('session.save_path = "tcp://redis-host:45629?auth=redis-pass"',
+            php_ini.update_lines.calls()[2].args[1])
+
+    def test_configure_adds_memcached_config_to_php_ini(self):
+        ctx = json.load(
+            open('tests/data/sessions/vcap_services_memcached.json'))
+        sessions = self.extension_module.SessionStoreConfig(ctx)
+        sessions.load_config = Dingus()
+        php_ini = Dingus()
+        sessions._php_ini = php_ini
+        sessions._php_ini_path = '/tmp/staged/app/php/etc/php.ini'
+        sessions.compile(None)
+        eq_(1, len(sessions.load_config.calls()))
+        eq_(3, len(php_ini.update_lines.calls()))
+        eq_(1, len(php_ini.append_lines.calls()))
+        eq_(True, all([arg.endswith('\n')
+                       for arg in php_ini.append_lines.calls()[0].args[0]]),
+            "Must end with EOL")
+        eq_(1, len(php_ini.save.calls()))
+        eq_(5, len(php_ini.calls()))
+        eq_('session.save_handler = memcached',
+            php_ini.update_lines.calls()[1].args[1])
+        eq_('session.save_path = "PERSISTENT=app_sessions host:port"',
+            php_ini.update_lines.calls()[2].args[1])


### PR DESCRIPTION
This PR adds code so the build pack will look at bound services and detect if a capable session store (currently redis or memcached) has been bound.  If one is found, it configures PHP to use the service for session storage instead of the default which is the local file system.

PR Includes:

  - new build pack extension with session functionality
  - docs for usage
  - set of unit tests to confirm basic functionality

Additional testing can be done with a simple script such as this one.

```
<?php
    if (! session_start()) {
        print 'Session Start Failed :(<br/>\n';
    }
?>
<html>
<head>
    <title>Session Test</title>
</head>
<body>
    <h1>Current Session Id: <?php print session_id(); ?></h1>
    <h1>Current Node: <?php print $_SERVER["SERVER_ADDR"]; ?></h1>
    <h3>Session Dump</h3>
    <pre><?php print_r($_SESSION); ?></pre>
    <h3>Session Counter Test</h3>
    <p>This app increments a counter.  When multiple instances of the app are deployed, the counter should still increase properly.</p>
    <?php
        if (! array_key_exists('counter', $_SESSION)) {
            $_SESSION['counter'] = 0;
        } else {
            $_SESSION['counter'] += 1;
        }
    ?>
    <h3>Counter: <?php print $_SESSION['counter']; ?></h3>
</body>
</html>
``` 

When enabled the output should be a counter that increments and the `Current Node` should rotate.