### PR TITLE
Fixing shadowed composer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ While the *30 Second Tutorial* shows how quick and easy it is to get started usi
   - [Example Applications](#examples)
   - [Usage]
   - [Configuration Options]
-  - [Composer]
+  - [Composer support]
   - [Binaries]
   - [Troubleshooting]
   - [Getting Help](#getting-help)
@@ -160,7 +160,7 @@ The project backlog is on [Pivotal Tracker](https://www.pivotaltracker.com/proje
 [Apache License]:http://www.apache.org/licenses/LICENSE-2.0
 [vcap-dev]:https://groups.google.com/a/cloudfoundry.org/forum/#!forum/vcap-dev
 [support forums]:http://support.run.pivotal.io/home
-[Composer]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/composer.md
+[Composer support]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/composer.md
 ["offline" mode]:https://github.com/cloudfoundry/php-buildpack/blob/master/docs/binaries.md#bundling-binaries-with-the-build-pack
 [phalcon]:https://github.com/dmikusa-pivotal/cf-ex-phalcon
 [Phalcon]:http://phalconphp.com/en/


### PR DESCRIPTION
both [more information section](https://github.com/cloudfoundry/php-buildpack/blob/master/README.md#more-information) and [example](section) point to  https://github.com/dmikusa-pivotal/cf-ex-composer It is therefore hard to find the composer doc at https://github.com/cloudfoundry/php-buildpack/blob/master/docs/composer.md which is not listed on the Readme.md.

This seems due to the markdown syntax with two references declared with same name (albeit different case) that end up being shadowed.