### PR TITLE
Composer build defaulting to webdir

### DIFF
--- a/defaults/options.json
+++ b/defaults/options.json
@@ -33,5 +33,6 @@
     "PHP_MODULES_STRIP": true,
     "PHP_MODULES": [],
     "PHP_EXTENSIONS": ["bz2", "zlib", "curl", "mcrypt"],
-    "ZEND_EXTENSIONS": []
+    "ZEND_EXTENSIONS": [],
+    "NO_WEBDIR_SET": false
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@ Here are a list of the options that an application developer might want to overr
 | HTTP_PROXY | Instruct the build pack to use an HTTP proxy to download resources accessed via http. |
 | HTTPS_PROXY | Instruct the build pack to use an HTTP proxy to download resources accessed via https. |
 | ADDITIONAL_PREPROCESS_CMDS | A list of additional commands that should be run prior to the application.  This allows developers a way to run things like migration scripts prior to the application being run. |
+| NO_WEBDIR_SET | Set to true if you don't want buildpack moves composer files out of `WEBDIR`. This var become true if no webdir has been set and if there is no default webdir (`htdocs`) available in sources. |
 
 ### HTTPD, Nginx and PHP configuration
 

--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -176,22 +176,8 @@ class ComposerExtension(ExtensionHelper):
     def _compile(self, install):
         self._builder = install.builder
         self.composer_runner = ComposerCommandRunner(self._ctx, self._builder)
-        self.move_local_vendor_folder()
         self.install()
         self.run()
-
-    def move_local_vendor_folder(self):
-        vendor_path = os.path.join(self._ctx['BUILD_DIR'],
-                                   self._ctx['WEBDIR'],
-                                   'vendor')
-        if os.path.exists(vendor_path):
-            self._log.debug("Vendor [%s] exists, moving to LIBDIR",
-                            vendor_path)
-            (self._builder.move()
-                .under('{BUILD_DIR}/{WEBDIR}')
-                .into('{BUILD_DIR}/{LIBDIR}')
-                .where_name_matches('^%s/.*$' % vendor_path)
-                .done())
 
     def install(self):
         self._builder.install().package('PHP').done()
@@ -280,13 +266,13 @@ class ComposerExtension(ExtensionHelper):
     def run(self):
         # Move composer files into root directory
         (json_path, lock_path) = find_composer_paths(self._ctx)
-        if json_path is not None and os.path.dirname(json_path) != self._ctx['BUILD_DIR']:
+        if json_path is not None and os.path.dirname(json_path) != self._ctx['BUILD_DIR'] and not self._ctx['NO_WEBDIR_SET']:
             (self._builder.move()
                 .under(os.path.dirname(json_path))
                 .where_name_is('composer.json')
                 .into('BUILD_DIR')
              .done())
-        if lock_path is not None and os.path.dirname(lock_path) != self._ctx['BUILD_DIR']:
+        if lock_path is not None and os.path.dirname(lock_path) != self._ctx['BUILD_DIR'] and not self._ctx['NO_WEBDIR_SET']:
             (self._builder.move()
                 .under(os.path.dirname(lock_path))
                 .where_name_is('composer.lock')
@@ -334,7 +320,8 @@ class ComposerCommandRunner(object):
             env[key] = val if type(val) == str else json.dumps(val)
 
         # add basic composer vars
-        env['COMPOSER_VENDOR_DIR'] = self._ctx['COMPOSER_VENDOR_DIR']
+        if not self._ctx['COMPOSER_VENDOR_DIR']:
+            env['COMPOSER_VENDOR_DIR'] = self._ctx['COMPOSER_VENDOR_DIR']
         env['COMPOSER_BIN_DIR'] = self._ctx['COMPOSER_BIN_DIR']
         env['COMPOSER_CACHE_DIR'] = self._ctx['COMPOSER_CACHE_DIR']
 
@@ -350,6 +337,9 @@ class ComposerCommandRunner(object):
         return env
 
     def run(self, *args):
+        buildDir = self._ctx['BUILD_DIR']
+        if self._ctx['NO_WEBDIR_SET']:
+            buildDir = os.path.join(buildDir, self._ctx['WEBDIR'])
         try:
             cmd = [self._php_path, self._composer_path]
             cmd.extend(args)
@@ -357,7 +347,7 @@ class ComposerCommandRunner(object):
             stream_output(sys.stdout,
                           ' '.join(cmd),
                           env=self._build_composer_environment(),
-                          cwd=self._ctx['BUILD_DIR'],
+                          cwd=buildDir,
                           shell=True)
         except:
             print "-----> Composer command failed"

--- a/lib/compile_helpers.py
+++ b/lib/compile_helpers.py
@@ -39,6 +39,7 @@ def setup_webdir_if_it_doesnt_exist(ctx):
     if is_web_app(ctx):
         webdirPath = os.path.join(ctx['BUILD_DIR'], ctx['WEBDIR'])
         if not os.path.exists(webdirPath):
+            ctx['NO_WEBDIR_SET'] = True
             fu = FileUtil(FakeBuilder(ctx), move=True)
             fu.under('BUILD_DIR')
             fu.into('WEBDIR')

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -23,7 +23,8 @@ class TestComposer(object):
             'CACHE_DIR': '/cache/dir',
             'PHP_VM': 'will_default_to_php_strategy',
             'WEBDIR': 'htdocs',
-            'LIBDIR': 'lib'
+            'LIBDIR': 'lib',
+            'NO_WEBDIR_SET': False
         })
         ct = self.extension_module.ComposerExtension(ctx)
         assert ct._should_compile()
@@ -34,7 +35,8 @@ class TestComposer(object):
             'CACHE_DIR': '/cache/dir',
             'PHP_VM': 'will_default_to_php_strategy',
             'WEBDIR': 'htdocs',
-            'LIBDIR': 'lib'
+            'LIBDIR': 'lib',
+            'NO_WEBDIR_SET': False
         })
         ct = self.extension_module.ComposerExtension(ctx)
         assert not ct._should_compile()
@@ -44,7 +46,8 @@ class TestComposer(object):
             'PHP_VM': 'will_default_to_php_strategy',
             'BUILD_DIR': '/build/dir',
             'CACHE_DIR': '/cache/dir',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
         builder = Dingus(_ctx=ctx)
         installer = Dingus()
@@ -74,7 +77,8 @@ class TestComposer(object):
             'CACHE_DIR': '/cache/dir',
             'COMPOSER_VERSION': 'latest',
             'BP_DIR': '',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
         builder = Dingus(_ctx=ctx)
         installer = Dingus()
@@ -105,7 +109,8 @@ class TestComposer(object):
             'TMPDIR': tempfile.gettempdir(),
             'WEBDIR': 'htdocs',
             'LIBDIR': 'lib',
-            'BP_DIR': ''
+            'BP_DIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -144,6 +149,7 @@ class TestComposer(object):
             'LIBDIR': 'lib',
             'BP_DEBUG': 'True',
             'BP_DIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus(return_value="""{"rate": {"limit": 60, "remaining": 60}}""")
@@ -184,7 +190,8 @@ class TestComposer(object):
             'WEBDIR': 'htdocs',
             'LIBDIR': 'lib',
             'COMPOSER_INSTALL_OPTIONS': ['--optimize-autoloader'],
-            'BP_DIR': ''
+            'BP_DIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -223,7 +230,8 @@ class TestComposer(object):
             'WEBDIR': '',
             'TMPDIR': tempfile.gettempdir(),
             'LIBDIR': 'lib',
-            'BP_DIR': ''
+            'BP_DIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -499,7 +507,8 @@ class TestComposer(object):
             'CACHE_DIR': '/tmp/cache',
             'PHP_VM': 'will_default_to_php_strategy',
             'LIBDIR': 'lib',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
         ct = self.extension_module.ComposerExtension(ctx)
         eq_('/tmp/build/lib/vendor', ct._ctx['COMPOSER_VENDOR_DIR'])
@@ -515,7 +524,8 @@ class TestComposer(object):
             'COMPOSER_BIN_DIR': '{BUILD_DIR}/bin',
             'PHP_VM': 'will_default_to_php_strategy',
             'COMPOSER_CACHE_DIR': '{CACHE_DIR}/custom',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
         ct = self.extension_module.ComposerExtension(ctx)
         eq_('/tmp/build/vendor', ct._ctx['COMPOSER_VENDOR_DIR'])
@@ -551,7 +561,8 @@ class TestComposer(object):
             'TMPDIR': 'tmp',
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'OUR_SPECIAL_KEY': 'SPECIAL_VALUE'
+            'OUR_SPECIAL_KEY': 'SPECIAL_VALUE',
+            'NO_WEBDIR_SET': False
         })
 
         environ_stub = Dingus()
@@ -581,7 +592,8 @@ class TestComposer(object):
             'CACHE_DIR': '/tmp/cache',
             'LIBDIR': 'lib',
             'TMPDIR': '/tmp',
-            'PHP_VM': 'php'
+            'PHP_VM': 'php',
+            'NO_WEBDIR_SET': False
         })
 
         write_config_stub = Dingus()
@@ -611,6 +623,7 @@ class TestComposer(object):
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
             'PHPRC': '/usr/awesome/phpini',
+            'NO_WEBDIR_SET': False
         })
 
         write_config_stub = Dingus()
@@ -636,6 +649,7 @@ class TestComposer(object):
             'CACHE_DIR': 'cache',
             'PHPRC': '/usr/awesome/phpini',
             'MY_DICTIONARY': {'KEY': 'VALUE'},
+            'NO_WEBDIR_SET': False
         })
 
         write_config_stub = Dingus()
@@ -662,7 +676,8 @@ class TestComposer(object):
             'TMPDIR': 'tmp',
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'SOME_KEY': utils.wrap('{exact_match}')
+            'SOME_KEY': utils.wrap('{exact_match}'),
+            'NO_WEBDIR_SET': False
         })
 
         write_config_stub = Dingus()
@@ -689,7 +704,8 @@ class TestComposer(object):
             'PHP_VM': 'php',
             'TMPDIR': 'tmp',
             'LIBDIR': 'lib',
-            'CACHE_DIR': 'cache'
+            'CACHE_DIR': 'cache',
+            'NO_WEBDIR_SET': False
         })
 
         write_config_stub = Dingus()
@@ -715,7 +731,8 @@ class TestComposer(object):
             'TMPDIR': 'tmp',
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'PATH': '/bin:/usr/bin'
+            'PATH': '/bin:/usr/bin',
+            'NO_WEBDIR_SET': False
         })
 
         write_config_stub = Dingus()
@@ -762,7 +779,8 @@ class TestComposer(object):
             'CACHE_DIR': 'cache',
             'COMPOSER_GITHUB_OAUTH_TOKEN': 'MADE_UP_TOKEN_VALUE',
             'BP_DIR': '',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -813,7 +831,8 @@ class TestComposer(object):
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
             'BP_DIR': '',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
         instance_stub = Dingus()
         instance_stub._set_return_value("""{"rate": {"limit": 60, "remaining": 60}}""")
@@ -851,7 +870,8 @@ class TestComposer(object):
             'TMPDIR': tempfile.gettempdir(),
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -885,7 +905,8 @@ class TestComposer(object):
             'TMPDIR': tempfile.gettempdir(),
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -911,7 +932,8 @@ class TestComposer(object):
             'TMPDIR': tempfile.gettempdir(),
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -938,7 +960,8 @@ class TestComposer(object):
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
             'BP_DIR': '',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         builder = Dingus(_ctx=ctx)
@@ -978,7 +1001,8 @@ class TestComposer(object):
             'TMPDIR': tempfile.gettempdir(),
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()
@@ -1004,7 +1028,8 @@ class TestComposer(object):
             'TMPDIR': tempfile.gettempdir(),
             'LIBDIR': 'lib',
             'CACHE_DIR': 'cache',
-            'WEBDIR': ''
+            'WEBDIR': '',
+            'NO_WEBDIR_SET': False
         })
 
         instance_stub = Dingus()


### PR DESCRIPTION
By default, composer app will install dependencies inside the `webdir` (as it work locally).
The var `"NO_WEBDIR_SET": "false"` as been created inside `defaults/options.json`. 
This var become true if no webdir has been set and if there is no default webdir (`htdocs`) available in sources.
**Important:**
 - **See discussion here**: [https://github.com/cloudfoundry/php-buildpack/issues/65](https://github.com/cloudfoundry/php-buildpack/issues/65)
 - **See the last PR here**: [https://github.com/cloudfoundry/php-buildpack/pull/67](https://github.com/cloudfoundry/php-buildpack/pull/67)

I've made a travis file to run test from this PR on another branch, all tests are green, see: [https://travis-ci.org/ArthurHlt/php-buildpack/builds/82896321](https://travis-ci.org/ArthurHlt/php-buildpack/builds/82896321)

**@flavorjones Can you merge it please? it's the third time I rewrote this PR**