### PR TITLE
Fixing Contributing link; adding Building link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ While the *30 Second Tutorial* shows how quick and easy it is to get started usi
   - [Getting Help](#getting-help)
   - [Development]
   - [License](#license)
-  - [Contributing](#contributing)
+  - [Building](#building)
+  - [Contributing](./CONTRIBUTING.md)
 
 ## Supported Software
 The [release notes page](https://github.com/cloudfoundry/php-buildpack/releases) has a list of currently supported modules and packages.


### PR DESCRIPTION
After chatting with @flavorjones & team, I think this might be helpful. I'm making the link in the README labeled "Contributing" actually go somewhere, and I'm also linking to the helpful "Building" guidance.