### PR TITLE
Buildpack fails to complete if the logging directory already exists.

### DIFF
--- a/lib/compile_helpers.py
+++ b/lib/compile_helpers.py
@@ -64,7 +64,9 @@ def log_bp_version(ctx):
 
 
 def setup_log_dir(ctx):
-    os.makedirs(os.path.join(ctx['BUILD_DIR'], 'logs'))
+    log_dir = os.path.join(ctx['BUILD_DIR'], 'logs')
+    if not os.path.isdir(log_dir):
+        os.makedirs(log_dir)
 
 
 def load_manifest(ctx):


### PR DESCRIPTION
When pushing to our CloudFoundry setup, all of a sudden the buildpack stopped working. The problem is that when attempting to create the logging directory, `os.makedirs()` will fail if the directory already exists. I don't think there is any reason why this should keep a push from completing. 

Inserting an `isdir` condition seemed like the most straight-forward solution to me and I'd prefer not to have to rely on my fork from now on. :) But if there is a better solution, please enlighten me.

For reference, here is the error output:

    ERR Traceback (most recent call last):
    ERR   File "/tmp/buildpacks/php-buildpack/scripts/compile.py", line 36, in <module>
    ERR     .method(setup_log_dir)
    ERR   File "/tmp/buildpacks/php-buildpack/lib/build_pack_utils/builder.py", line 493, in method
    ERR     execute(self.builder._ctx)
    ERR   File "/tmp/buildpacks/php-buildpack/lib/compile_helpers.py", line 67, in setup_log_dir
    ERR     os.makedirs(os.path.join(ctx['BUILD_DIR'], 'logs'))
    ERR   File "/usr/lib/python2.7/os.py", line 157, in makedirs
    ERR     mkdir(name, mode)
    ERR OSError: [Errno 17] File exists: '/tmp/staged/app/logs'