### PR TITLE
Update new relic extension to 6.3.0.161

### DIFF
--- a/extensions/newrelic/extension.py
+++ b/extensions/newrelic/extension.py
@@ -26,7 +26,7 @@ _log = logging.getLogger('newrelic')
 
 DEFAULTS = {
     'NEWRELIC_HOST': 'download.newrelic.com',
-    'NEWRELIC_VERSION': '4.23.3.111',
+    'NEWRELIC_VERSION': '6.3.0.161',
     'NEWRELIC_PACKAGE': 'newrelic-php5-{NEWRELIC_VERSION}-linux.tar.gz',
     'NEWRELIC_DOWNLOAD_URL': 'https://{NEWRELIC_HOST}/php_agent/'
                              'archive/{NEWRELIC_VERSION}/{NEWRELIC_PACKAGE}',


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

The older version doesn't support PHP 7 and staging fails when you try to use newrelic and PHP 7 together. See also #146 

* An explanation of the use cases your change solves

New relic works again on PHP 7

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch
