### PR TITLE
Disable `opcache.validate_timestamps` by default.

### DIFF
--- a/defaults/config/php/5.6.x/php.ini
+++ b/defaults/config/php/5.6.x/php.ini
@@ -1863,7 +1863,11 @@ ldap.max_links = -1
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.
-;opcache.validate_timestamps=1
+; ----
+; CF build pack sets this to zero because app files should not change
+;  after the build pack runs and stages the application.
+; ----
+opcache.validate_timestamps=0
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only

--- a/defaults/config/php/7.0.x/php.ini
+++ b/defaults/config/php/7.0.x/php.ini
@@ -1863,7 +1863,11 @@ ldap.max_links = -1
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.
-;opcache.validate_timestamps=1
+; ----
+; CF build pack sets this to zero because app files should not change
+;  after the build pack runs and stages the application.
+; ----
+opcache.validate_timestamps=0
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only

--- a/defaults/config/php/7.1.x/php.ini
+++ b/defaults/config/php/7.1.x/php.ini
@@ -1863,7 +1863,11 @@ ldap.max_links = -1
 
 ; When disabled, you must reset the OPcache manually or restart the
 ; webserver for changes to the filesystem to take effect.
-;opcache.validate_timestamps=1
+; ----
+; CF build pack sets this to zero because app files should not change
+;  after the build pack runs and stages the application.
+; ----
+opcache.validate_timestamps=0
 
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

This has performance gains and it should not impact apps, as application code should not change after you `cf push` an application.  Disabling this function tells the opcache to stop looking for changes to code.

* An explanation of the use cases your change solves

This improves performance for anyone that enables opcache.  Opcache is not enabled by default and would require a user to add the opcache extension + enable it.

* [ ] I have viewed signed and have submitted the Contributor License Agreement

Yes.

* [ ] I have made this pull request to the `develop` branch

Yes

* [ ] I have added an integration test

Not sure how to test this.  It's a config only change.