### PR TITLE
Updated the agent download url

### DIFF
--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -88,7 +88,7 @@ class DynatraceInstaller(object):
     def download_paas_agent_installer(self):
         self.create_folder(os.path.join(self._ctx['BUILD_DIR'], 'dynatrace'))
         installer = self._get_paas_installer_path()
-        url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token=' + self._ctx['DYNATRACE_TOKEN'] + '&bitness=64&include=php,nginx,apache'
+        url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token=' + self._ctx['DYNATRACE_TOKEN'] + '&bitness=64&include=php&include=nginx&include=apache'
         req = urllib2.Request(url)
         res = urllib2.urlopen(req)
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Server-side download URL changed, so we adapted it do the new format

* An explanation of the use cases your change solves
The Dynatrace agent wasn't downloadable anymore after a bugfix on the server component

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
No new integration test (the existing integration test is still valid), since we agreed on download only a dummy installer script which doesn't care about the query parameters (as agreed with @dgodd on the first extension implementation).
