### PR TITLE
Add newrelic 7.4.0.198, remove newrelic 6.3.0.161 - fixes #215

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+UNRELEASED
+=====================
+
+* Add newrelic 7.4.0.198, remove newrelic 6.3.0.161
+  (https://www.pivotaltracker.com/story/show/147822451)
+
 v4.3.37 Jul 10, 2017
 =====================
 
@@ -155,10 +161,10 @@ v4.3.29 Mar 15, 2017
 v4.3.28 Feb 27, 2017
 =====================
 
-* Add geoip PECL extension 
+* Add geoip PECL extension
   (https://www.pivotaltracker.com/story/show/138843171)
 
-* Ensure buildpack does not warn about extensions that are compiled into PHP 
+* Ensure buildpack does not warn about extensions that are compiled into PHP
   (https://www.pivotaltracker.com/story/show/138757115)
 
 * Add nginx 1.11.10, remove nginx 1.11.9
@@ -461,7 +467,7 @@ v4.3.14 Jun 02, 2016
   (https://www.pivotaltracker.com/story/show/120614839)
   (https://www.pivotaltracker.com/story/show/120624623)
 
-* Updating New Relic extension from v4.23.3.111 to v6.3.0.161
+* Updating New Relic extension from v4.23.3.111 to v7.4.0.198
   (https://www.pivotaltracker.com/story/show/119709645)
 
 * Update composer to 1.1.2

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,7 +18,7 @@ default_versions:
 - name: httpd
   version: 2.4.26
 - name: newrelic
-  version: 6.3.0.161
+  version: 7.4.0.198
 - name: composer
   version: 1.4.2
 - name: nginx
@@ -49,8 +49,8 @@ dependency_deprecation_dates:
   name: php
   date: 2019-12-01
   link: http://php.net/supported-versions.php
-- match: 6.3.0.161
-  version_line: 6.3.0.161
+- match: 7.4.0.198
+  version_line: 7.4.0.198
   name: newrelic
   date: 2019-05-18
   link: https://docs.newrelic.com/docs/agents/manage-apm-agents/maintenance/new-relic-agent-plugin-end-life-policy
@@ -61,8 +61,8 @@ dependency_deprecation_dates:
   link: https://www.nginx.com/blog/nginx-1-10-1-11-released/
 dependencies:
 - name: newrelic
-  version: 6.3.0.161
-  uri: https://download.newrelic.com/php_agent/archive/6.3.0.161/newrelic-php5-6.3.0.161-linux.tar.gz
+  version: 7.4.0.198
+  uri: https://download.newrelic.com/php_agent/archive/7.4.0.198/newrelic-php5-7.4.0.198-linux.tar.gz
   cf_stacks:
   - cflinuxfs2
   md5: 3640d3cad6b5199f54a6b54a627235d6

--- a/tests/data/composer-default-versions/manifest.yml
+++ b/tests/data/composer-default-versions/manifest.yml
@@ -20,7 +20,7 @@ default_versions:
 - name: httpd
   version: 2.4.23
 - name: newrelic
-  version: 6.3.0.161
+  version: 7.4.0.198
 - name: composer
   version: 9.9.9
 url_to_dependency_map:

--- a/tests/test_newrelic.py
+++ b/tests/test_newrelic.py
@@ -302,8 +302,8 @@ default_versions:
 
 dependencies:
 - name: newrelic
-  version: 6.3.0.161
-  uri: https://download.newrelic.com/php_agent/archive/6.3.0.161/newrelic-php5-6.3.0.161-linux.tar.gz
+  version: 7.4.0.198
+  uri: https://download.newrelic.com/php_agent/archive/7.4.0.198/newrelic-php5-7.4.0.198-linux.tar.gz
   cf_stacks:
   - cflinuxfs2
   md5: 3640d3cad6b5199f54a6b54a627235d6
@@ -324,8 +324,8 @@ default_versions:
 
 dependencies:
 - name: newrelic
-  version: 6.3.0.161
-  uri: https://download.newrelic.com/php_agent/archive/6.3.0.161/newrelic-php5-6.3.0.161-linux.tar.gz
+  version: 7.4.0.198
+  uri: https://download.newrelic.com/php_agent/archive/7.4.0.198/newrelic-php5-7.4.0.198-linux.tar.gz
   cf_stacks:
   - cflinuxfs2
   md5: 3640d3cad6b5199f54a6b54a627235d6


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: Upgrade the newrelic agent to [version 7.4.0.198](https://docs.newrelic.com/docs/release-notes/agent-release-notes/php-release-notes/php-agent-740198)
