### PR TITLE
Docs for non-core extension magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,19 @@ Of these, the `detect` and `release` scripts are straightforward, providing the 
   - setup the runtime environment and process manager
   - generate a startup.sh script
 
-In general, you shouldn't need to modify the buildpack itself.  Instead creating an extension should be the way to go.
-
 ### Extensions
 
-The buildpack relies heavily on extensions.  An extension is simply a set of Python methods that will get called at various times during the staging process.  
+The buildpack relies heavily on extensions.  An extension is simply a set of Python methods that will get called at various times during the staging process.
 
-### Creation
+### Adding extensions
 
-To create an extension, simply create a folder.  The name of the folder will be the extension.  Inside that folder, create a file called `extension.py`. That file will contain your code.  Inside that file, put your extension methods and any additional required code.
+In general, you shouldn't need to modify the buildpack itself.  Instead creating your own extension should be the way to go.
 
-### Methods
+To create an extension, simply create a folder.  The name of the folder will be the name of the extension.  Inside that folder, create a file called `extension.py`. That file will contain your code.  Inside that file, put your extension methods and any additional required code.
+
+It's not necessary to fork the buildpack to add extensions for your app. The buildpack will notice and use extensions if you place them in a `.extensions` folder at your application root. See the [extensions directory in the `cf-ex-wordpress` example](https://github.com/cloudfoundry-samples/cf-ex-wordpress/tree/master/.extensions/wordpress) for a sample.
+
+#### Methods
 
 Here is an explanation of the methods offered to an extension developer.  All of them are optional and if a method is not implemented, it is simply skipped.
 
@@ -167,7 +169,7 @@ The `compile` method is the main method and where extension authors should perfo
 
 The method is given one argument which is an Installer builder object.  The object can be used to install packages, configuration files or access the context (for examples of all this, see the core extensions like [HTTPD], [Nginx], [PHP], [Dynatrace] and [NewRelic]).  The method should return 0 when successful or any other number when it fails.  Optionally, the extension can raise an exception.  This will also signal a failure and it can provide more details about why something failed.
 
-### Method Order
+#### Method Order
 
 It is sometimes useful to know what order the buildpack will use to call the methods in an extension.  They are called in the following order.
 
@@ -217,7 +219,7 @@ def compile(install):
     return 0
 ```
 
-### Tips
+#### Tips
 
  1. To be consistent with the rest of the buildpack, extensions should import and use the standard logging module.  This will allow extension output to be incorporated into the output for the rest of the buildpack.
  1. The buildpack will run every extension that is included with the buildpack and the application.  There is no mechanism to disable specific extensions.  Thus, when you write an extension, you should make some way for the user to enable / disable it's functionality.  See the [NewRelic] extension for an example of this.

--- a/README.md
+++ b/README.md
@@ -101,18 +101,20 @@ Of these, the `detect` and `release` scripts are straightforward, providing the 
 
 The buildpack relies heavily on extensions.  An extension is simply a set of Python methods that will get called at various times during the staging process.
 
-Included extensions:
-- [composer](extensions/composer) - TODO summary
-  - TODO description
-- [dynatrace](extensions/dynatrace) - TODO summary
-  - TODO description
-- [geoip](extensions/geoip) - TODO summary
-  - TODO description
-- [newrelic](extensions/newrelic) - TODO summary
-  - TODO description
-- [`session`](extensions/session) - Configures PHP to store session information in a bound Redis or Memcached service instance
-  - Simply bind a Redis service called `redis-sessions` or a Memcached service called `memcached-sessions` to the app, and the extension takes care of reading the environment for the location of the service and configuring PHP to use it.
- 
+Included non-core extensions:
+- [`composer`](extensions/composer) - [Downloads, installs and runs Composer](http://docs.cloudfoundry.org/buildpacks/php/gsg-php-composer.html)
+- [`dynatrace`](extensions/dynatrace) - Downloads and configures Dynatrace OneAgent
+  - Looks for a bound service with name `dynatrace` and value `credentials` with sub-keys
+    - `apiurl`
+    - `environmentid`
+    - `apitoken`
+- [`geoip`](extensions/geoip) - Configures geoip & optionally downloads geoip databases
+  - Looks for a bound service with name `geoip-service` and value `credentials` with sub-keys
+    - `username`
+    - `license`
+    - `products`
+- [`newrelic`](extensions/newrelic) - [Downloads, installs and configures the NewRelic agent for PHP](http://docs.cloudfoundry.org/buildpacks/php/gsg-php-newrelic.html)
+- [`session`](extensions/session) - [Configures PHP to store session information in a bound Redis or Memcached service instance](http://docs.cloudfoundry.org/buildpacks/php/gsg-php-sessions.html) 
 
 ### Adding extensions
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Of these, the `detect` and `release` scripts are straightforward, providing the 
 
 The buildpack relies heavily on extensions.  An extension is simply a set of Python methods that will get called at various times during the staging process.
 
+Included extensions:
+- [composer](extensions/composer) - TODO summary
+  - TODO description
+- [dynatrace](extensions/dynatrace) - TODO summary
+  - TODO description
+- [geoip](extensions/geoip) - TODO summary
+  - TODO description
+- [newrelic](extensions/newrelic) - TODO summary
+  - TODO description
+- [`session`](extensions/session) - Configures PHP to store session information in a bound Redis or Memcached service instance
+  - Simply bind a Redis service called `redis-sessions` or a Memcached service called `memcached-sessions` to the app, and the extension takes care of reading the environment for the location of the service and configuring PHP to use it.
+ 
+
 ### Adding extensions
 
 In general, you shouldn't need to modify the buildpack itself.  Instead creating your own extension should be the way to go.

--- a/extensions/sessions/extension.py
+++ b/extensions/sessions/extension.py
@@ -15,6 +15,10 @@
 """Session Config Extension
 
 Configures redis or memcached for session sharing
+
+Simply create a service instance called either `redis-sessions` or 
+`memcached-sessions`, bind it to the app, and the extension takes care of 
+the rest.
 """
 from extension_helpers import PHPExtensionHelper
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Help users figure out how to use the non-core extensions

* An explanation of the use cases your change solves

Phil the PHP developer is excited about porting his PHP application to a Cloud Foundry deployment. He sees flaky behavior as soon as his app is scaled to multiple instances and pretty soon he traces it down to the fact that the app instances are not sharing session data. He's unsure how to make the app stateless because he's never had to deal with putting PHP sessions in external storage before; even having multiple instances seems like a big deal!  Phil goes down a long Google/Stack Overflow 🐰 🕳 to figure out what he needs to do to have PHP use sessions in external storage. He has no idea how to do that in Cloud Foundry; it's all magic! What does a buildpack do anyway? Along the way Phil gets tired and decides that maybe with all this effort, selecting Cloud Foundry as a place to host this app was a bad idea... Surely every app has this problem, and if it's not trivial to solve and requires this much fine tweaking, maybe Cloud Foundry is only useful for toy examples and would be a bad place to host his app. Phil gives up and goes back to Digital Ocean... Oh well.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [-] I have added an integration test
