### PR TITLE
Lots of additions to the Dynatrace extension

### DIFF
--- a/cf_spec/integration/deploy_a_php_app_with_dynatrace_spec.rb
+++ b/cf_spec/integration/deploy_a_php_app_with_dynatrace_spec.rb
@@ -1,7 +1,7 @@
 $: << 'cf_spec'
 require 'cf_spec_helper'
 
-describe 'CF PHP Buildpack' do
+describe 'Deploy app with single dynatrace service without manifest.json' do
   context '' do
     let(:browser) {
       Machete::Browser.new(@app)
@@ -13,7 +13,7 @@ describe 'CF PHP Buildpack' do
       @app = deploy_app(@app_name, @env_config)
       @dynatrace_service_name = "dynatrace-test-service-php-#{Random.rand(100000)}"
 
-      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name} -p '{"apitoken":"","apiurl":"https://s3.amazonaws.com/dt-paas","environmentid":"envid"}'))
+      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name} -p '{"apitoken":"TOKEN","apiurl":"https://s3.amazonaws.com/dt-paas","environmentid":"envid"}'))
       Machete::SystemHelper.run_cmd(%(cf bind-service #{@app_name} #{@dynatrace_service_name}))
       Machete::SystemHelper.run_cmd(%(cf restage #{@app_name}))
     end
@@ -25,6 +25,10 @@ describe 'CF PHP Buildpack' do
 
     it 'initializing dynatrace agent' do
      expect(@app).to have_logged 'Initializing'
+    end
+
+    it 'detecting single dynatrace service' do
+     expect(@app).to have_logged 'Found one matching Dynatrace service'
     end
 
     it 'downloading dynatrace agent' do
@@ -46,5 +50,216 @@ describe 'CF PHP Buildpack' do
     it 'LD_PRELOAD settings' do
      expect(@app).to have_logged 'Adding Dynatrace LD_PRELOAD settings'
     end
+
+    it 'checking for manifest.json fallback' do
+     expect(@app).to have_logged 'Agent path not found in manifest.json, using fallback'
+    end
   end
 end
+
+describe 'Deploy app with single dynatrace service and manifest.json' do
+  context '' do
+    let(:browser) {
+      Machete::Browser.new(@app)
+    }
+
+    before(:all) do
+      @env_config = {env: {'BP_DEBUG' => 'true' }}
+      @app_name = 'with_dynatrace'
+      @app = deploy_app(@app_name, @env_config)
+      @dynatrace_service_name = "dynatrace-test-service-php-#{Random.rand(100000)}"
+
+      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name} -p '{"apitoken":"TOKEN","apiurl":"https://s3.amazonaws.com/dt-paas/manifest","environmentid":"envid"}'))
+      Machete::SystemHelper.run_cmd(%(cf bind-service #{@app_name} #{@dynatrace_service_name}))
+      Machete::SystemHelper.run_cmd(%(cf restage #{@app_name}))
+    end
+
+    after(:all) do
+      Machete::CF::DeleteApp.new.execute(@app)
+      Machete::SystemHelper.run_cmd(%(cf delete-service -f #{@dynatrace_service_name}))
+    end
+
+    it 'initializing dynatrace agent' do
+     expect(@app).to have_logged 'Initializing'
+    end
+
+    it 'detecting single dynatrace service' do
+     expect(@app).to have_logged 'Found one matching Dynatrace service'
+    end
+
+    it 'downloading dynatrace agent' do
+     expect(@app).to have_logged 'Downloading Dynatrace PAAS-Agent Installer'
+    end
+
+    it 'extracting dynatrace agent' do
+     expect(@app).to have_logged 'Extracting Dynatrace PAAS-Agent'
+    end
+
+    it 'removing dynatrace agent installer' do
+     expect(@app).to have_logged 'Removing Dynatrace PAAS-Agent Installer'
+    end
+
+    it 'adding environment vars' do
+     expect(@app).to have_logged 'Adding Dynatrace specific Environment Vars'
+    end
+
+    it 'LD_PRELOAD settings' do
+     expect(@app).to have_logged 'Adding Dynatrace LD_PRELOAD settings'
+    end
+
+    it 'using manifest.json' do
+     expect(@app).to have_logged 'Using manifest.json'
+    end
+  end
+end
+
+describe 'Deploy app with multiple dynatrace services' do
+  context '' do
+    let(:browser) {
+      Machete::Browser.new(@app)
+    }
+
+    before(:all) do
+      @env_config = {env: {'BP_DEBUG' => 'true' }}
+      @app_name = 'with_dynatrace'
+      @app = deploy_app(@app_name, @env_config)
+      @dynatrace_service_name = "dynatrace-test-service-php-#{Random.rand(100000)}"
+      @dynatrace_service_name_dupe = "dynatrace-test-service-php-#{Random.rand(100000)}"
+
+      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name} -p '{"apitoken":"TOKEN","apiurl":"https://s3.amazonaws.com/dt-paas","environmentid":"envid"}'))
+      Machete::SystemHelper.run_cmd(%(cf bind-service #{@app_name} #{@dynatrace_service_name}))
+
+      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name_dupe} -p '{"apitoken":"TOKEN","apiurl":"https://s3.amazonaws.com/dt-paas","environmentid":"envid_dupe"}'))
+      Machete::SystemHelper.run_cmd(%(cf bind-service #{@app_name} #{@dynatrace_service_name_dupe}))
+
+      Machete::SystemHelper.run_cmd(%(cf restage #{@app_name}))
+    end
+
+    after(:all) do
+      Machete::CF::DeleteApp.new.execute(@app)
+      Machete::SystemHelper.run_cmd(%(cf delete-service -f #{@dynatrace_service_name}))
+      Machete::SystemHelper.run_cmd(%(cf delete-service -f #{@dynatrace_service_name_dupe}))
+    end
+
+    it 'initializing dynatrace agent' do
+     expect(@app).to have_logged 'Initializing'
+    end
+
+    it 'detecting multiple dynatrace services' do
+     expect(@app).to have_logged 'More than one matching service found!'
+    end
+
+    it 'deployment should fail' do
+     expect(@app).to_not be_running
+    end
+  end
+end
+
+describe 'Deploy app with single dynatrace service, wrong url and skiperrors on true' do
+  context '' do
+    let(:browser) {
+      Machete::Browser.new(@app)
+    }
+
+    before(:all) do
+      @env_config = {env: {'BP_DEBUG' => 'true' }}
+      @app_name = 'with_dynatrace'
+      @app = deploy_app(@app_name, @env_config)
+      @dynatrace_service_name = "dynatrace-test-service-php-#{Random.rand(100000)}"
+
+      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name} -p '{"apitoken":"TOKEN","apiurl":"https://s3.amazonaws.com/dt-paasFAIL","environmentid":"envid","skiperrors":"true"}'))
+      Machete::SystemHelper.run_cmd(%(cf bind-service #{@app_name} #{@dynatrace_service_name}))
+      Machete::SystemHelper.run_cmd(%(cf restage #{@app_name}))
+    end
+
+    after(:all) do
+      Machete::CF::DeleteApp.new.execute(@app)
+      Machete::SystemHelper.run_cmd(%(cf delete-service -f #{@dynatrace_service_name}))
+    end
+
+    it 'initializing dynatrace agent' do
+     expect(@app).to have_logged 'Initializing'
+    end
+
+    it 'detecting single dynatrace service' do
+     expect(@app).to have_logged 'Found one matching Dynatrace service'
+    end
+
+    it 'downloading dynatrace agent' do
+     expect(@app).to have_logged 'Downloading Dynatrace PAAS-Agent Installer'
+    end
+
+    it 'download retries work' do
+     expect(@app).to have_logged 'Error during installer download, retrying in 4 seconds'
+     expect(@app).to have_logged 'Error during installer download, retrying in 5 seconds'
+     expect(@app).to have_logged 'Error during installer download, retrying in 7 seconds'
+    end
+
+    it 'should exit gracefully' do
+     expect(@app).to have_logged 'Error during installer download, skipping installation'
+    end
+
+    it 'no further installer logs' do
+     expect(@app).to_not have_logged 'Extracting Dynatrace PAAS-Agent'
+    end
+
+    it 'deployment should not fail' do
+     expect(@app).to be_running
+    end
+  end
+end
+
+describe 'Deploy app with single dynatrace service, wrong url and skiperrors not set' do
+  context '' do
+    let(:browser) {
+      Machete::Browser.new(@app)
+    }
+
+    before(:all) do
+      @env_config = {env: {'BP_DEBUG' => 'true' }}
+      @app_name = 'with_dynatrace'
+      @app = deploy_app(@app_name, @env_config)
+      @dynatrace_service_name = "dynatrace-test-service-php-#{Random.rand(100000)}"
+
+      Machete::SystemHelper.run_cmd(%(cf cups #{@dynatrace_service_name} -p '{"apitoken":"TOKEN","apiurl":"https://s3.amazonaws.com/dt-paasFAIL","environmentid":"envid"}'))
+      Machete::SystemHelper.run_cmd(%(cf bind-service #{@app_name} #{@dynatrace_service_name}))
+      Machete::SystemHelper.run_cmd(%(cf restage #{@app_name}))
+    end
+
+    after(:all) do
+      Machete::CF::DeleteApp.new.execute(@app)
+      Machete::SystemHelper.run_cmd(%(cf delete-service -f #{@dynatrace_service_name}))
+    end
+
+    it 'initializing dynatrace agent' do
+     expect(@app).to have_logged 'Initializing'
+    end
+
+    it 'detecting single dynatrace service' do
+     expect(@app).to have_logged 'Found one matching Dynatrace service'
+    end
+
+    it 'downloading dynatrace agent' do
+     expect(@app).to have_logged 'Downloading Dynatrace PAAS-Agent Installer'
+    end
+
+    it 'download retries work' do
+     expect(@app).to have_logged 'Error during installer download, retrying in 4 seconds'
+     expect(@app).to have_logged 'Error during installer download, retrying in 5 seconds'
+     expect(@app).to have_logged 'Error during installer download, retrying in 7 seconds'
+    end
+
+    it 'error during agent download' do
+     expect(@app).to have_logged 'ERROR: Dynatrace agent download failed'
+    end
+
+    it 'no further installer logs' do
+     expect(@app).to_not have_logged 'Extracting Dynatrace PAAS-Agent'
+    end
+
+    it 'deployment should fail' do
+     expect(@app).to_not be_running
+    end
+  end
+end
+

--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -21,6 +21,8 @@ import os
 import logging
 from subprocess import call
 import urllib2
+import json
+import time
 
 _log = logging.getLogger('dynatrace')
 
@@ -29,6 +31,7 @@ class DynatraceInstaller(object):
         self._log = _log
         self._ctx = ctx
         self._detected = False
+        self._run_installer = True
         self.app_name = None
         self.dynatrace_server = None
         try:
@@ -47,34 +50,31 @@ class DynatraceInstaller(object):
 
     # verify if 'dynatrace' service is available
     def _load_service_info(self):
-        dynatrace = False
         detected_services = []
         vcap_services = self._ctx.get('VCAP_SERVICES', {})
         for provider, services in vcap_services.iteritems():
             for service in services:
                 if 'dynatrace' in service.get('name', ''):
-                    dynatrace = service
-                    creds = dynatrace.get('credentials', {})
-                    if (creds.get('apiurl', None) != None or creds.get('environmentid', None) != None) and creds.get('apitoken', None) != None:
+                    creds = service.get('credentials', {})
+                    if creds.get('environmentid', None) and creds.get('apitoken', None):
                         detected_services.append(creds)
                     else:
                         self._log.info("Dynatrace service detected. But without proper credentials!")
-                        dynatrace = False
 
         if len(detected_services) == 1:
             self._log.info("Found one matching Dynatrace service")
-            creds = dynatrace.get('credentials', {})
-            self._ctx['DYNATRACE_API_URL'] = creds.get('apiurl', None)
-            self._ctx['DYNATRACE_ENVIRONMENT_ID'] = creds.get('environmentid', None)
-            self._ctx['DYNATRACE_TOKEN'] = creds.get('apitoken', None)
 
-            if (self._ctx['DYNATRACE_API_URL'] != None or self._ctx['DYNATRACE_ENVIRONMENT_ID'] != None) and self._ctx['DYNATRACE_TOKEN'] != None:
-                self._log.info("Dynatrace credentials detected.")
-                self._convert_api_url()
-                self._detected = True
+            self._ctx['DYNATRACE_API_URL'] = detected_services[0].get('apiurl', None)
+            self._ctx['DYNATRACE_ENVIRONMENT_ID'] = detected_services[0].get('environmentid', None)
+            self._ctx['DYNATRACE_TOKEN'] = detected_services[0].get('apitoken', None)
+            self._ctx['DYNATRACE_SKIPERRORS'] = detected_services[0].get('skiperrors', None)
+
+            self._convert_api_url()
+            self._detected = True
+
         elif len(detected_services) > 1:
-            self._log.info("More than one matching service found!")
-            self._detected = False
+            self._log.warning("More than one matching service found!")
+            raise SystemExit(1)
 
     # returns paas-installer path
     def _get_paas_installer_path(self):
@@ -88,20 +88,46 @@ class DynatraceInstaller(object):
         if not os.path.exists(directory):
             os.makedirs(directory)
 
+    def _retry_download(self, url, dest):
+        tries = 3
+        base_waittime = 3
+
+        for attempt in range(tries):
+            try:
+                result = urllib2.urlopen(url)
+                f = open(dest, 'w')
+                f.write(result.read())
+                f.close()
+                return
+            except IOError, exc:
+                last_exception = exc
+                waittime = base_waittime + 2**attempt
+                _log.warn("Error during installer download, retrying in %s seconds" % (waittime))
+                time.sleep(waittime)
+
+        raise last_exception
+
     # downloading the paas agent from the 'DYNATRACE_API_URL'
     def download_paas_agent_installer(self):
         self.create_folder(os.path.join(self._ctx['BUILD_DIR'], 'dynatrace'))
         installer = self._get_paas_installer_path()
         url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?Api-Token=' + self._ctx['DYNATRACE_TOKEN'] + '&bitness=64&include=php&include=nginx&include=apache'
-        req = urllib2.Request(url)
-        res = urllib2.urlopen(req)
+        skiperrors = self._ctx['DYNATRACE_SKIPERRORS']
 
-        f = open(installer, 'w')
-        f.write(res.read())
-        f.close()
+        try:
+            self._retry_download(url, installer)
+            os.chmod(installer, 0o777)
+        except IOError, exc:
+            if skiperrors == 'true':
+                _log.warn('Error during installer download, skipping installation: %s' % (exc))
+                self._run_installer = False
+            else:
+                _log.error('ERROR: Dynatrace agent download failed')
+                raise
 
-        os.chmod(installer, 0o777)
 
+    def run_installer(self):
+        return self._run_installer
     # executing the downloaded paas-installer
     def extract_paas_agent(self):
         installer = self._get_paas_installer_path()
@@ -125,7 +151,25 @@ class DynatraceInstaller(object):
         vcap_app = self._ctx.get('VCAP_APPLICATION', {})
         app_name = vcap_app.get('name', None)
         envfile    = os.path.join(self._ctx['BUILD_DIR'], '.profile.d', 'dynatrace-env.sh')
-        agent_path = os.path.join(self._ctx['HOME'], 'app', 'dynatrace', 'oneagent', 'agent', 'lib64', 'liboneagentproc.so')
+        agent_path = None
+        manifest_file = os.path.join(self._ctx['BUILD_DIR'], 'dynatrace', 'oneagent', 'manifest.json')
+
+        if os.path.isfile(manifest_file):
+            manifest = json.load(open(manifest_file))
+            process_technology = manifest['technologies'].get('process')
+            if process_technology:
+                for entry in process_technology['linux-x86-64']:
+                    if entry.get('binarytype') == 'primary':
+                        _log.info("Using manifest.json")
+                        agent_path = entry['path']
+
+        if not agent_path:
+            _log.warning("Agent path not found in manifest.json, using fallback")
+            agent_path = os.path.join('agent', 'lib64', 'liboneagentproc.so')
+
+        # prepending agent path with installer directory
+        agent_path = os.path.join(self._ctx['HOME'], 'app', 'dynatrace', 'oneagent', agent_path)
+
         ld_preload = '\nexport LD_PRELOAD="' + agent_path + '"'
         host_name  = '\nexport DT_HOST_ID=' + app_name + '_${CF_INSTANCE_INDEX}'
         with open(envfile, "a") as file:
@@ -137,12 +181,13 @@ def compile(install):
     if dynatrace.should_install():
         _log.info("Downloading Dynatrace PAAS-Agent Installer")
         dynatrace.download_paas_agent_installer()
-        _log.info("Extracting Dynatrace PAAS-Agent")
-        dynatrace.extract_paas_agent()
-        _log.info("Removing Dynatrace PAAS-Agent Installer")
-        dynatrace.cleanup_paas_installer()
-        _log.info("Adding Dynatrace specific Environment Vars")
-        dynatrace.adding_environment_variables()
-        _log.info("Adding Dynatrace LD_PRELOAD settings")
-        dynatrace.adding_ld_preload_settings()
+        if dynatrace.run_installer():
+            _log.info("Extracting Dynatrace PAAS-Agent")
+            dynatrace.extract_paas_agent()
+            _log.info("Removing Dynatrace PAAS-Agent Installer")
+            dynatrace.cleanup_paas_installer()
+            _log.info("Adding Dynatrace specific Environment Vars")
+            dynatrace.adding_environment_variables()
+            _log.info("Adding Dynatrace LD_PRELOAD settings")
+            dynatrace.adding_ld_preload_settings()
     return 0


### PR DESCRIPTION
* A short explanation of the proposed change:
Added a bunch of things to the Dynatrace extension:
- detection if there is more than one credential service, if yes: fail, since that is not supported.
- download retry: failed installer downloads retry 3 times with exponential backoff. This should help prevent issues with mass deployments and download throttling.
- skiperrors flag: gives the user/customer the option to ignore errors from the installer download. It will then just skip the rest of the steps after the download and the overall app deployment doesn't fail. This is a request we had from various customers to prevent failing app deployments in case of small network hickups or throttling issues.
- the path to the agent binary is now taken from the manifest.json file instead of being hardcoded into the extension. This makes it failsafer and future changes in filepaths do not require changes to the buildpack-extension anymore.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
