### PR TITLE
Don't translate composer.json PHP version

### DIFF
--- a/extensions/composer/extension.py
+++ b/extensions/composer/extension.py
@@ -100,7 +100,7 @@ class ComposerConfiguration(object):
         # requested is coming from the composer.json file and is a unicode string type.
         # Since it's just a semver string, it shouldn't actually contain any unicode
         # characters. So it should be safe to turn it into an ASCII string
-        translated_requirement = str(requested.replace('>=', '~>'))
+        translated_requirement = str(requested)
 
         selected = max_satisfying(self._ctx['ALL_PHP_VERSIONS'], translated_requirement, loose=False)
 


### PR DESCRIPTION
* A short explanation of the proposed change:

`~>` and `>=` have different meanings. The comment stated that it was translating to an ASCII string, but it also was changing the version requirement for PHP.

* An explanation of the use cases your change solves

Could have some major implications as it changes the default behavior of the buildpack, but it aligns more with what the composer.json actually states and specifies. If `>=7.0.0` is provided, it means that the project _should_ work with PHP 7.1.X or PHP 7.2.X as well. Given the current logic, only 7.0.0 could be used, which presents certain security concerns as well as long-term issues if someone wants to use/test against a newer version of PHP but are unable to do so because the current buildpack locks them in at the defined version.

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [X] I have added an integration test
