### PR TITLE
Configure HTTPD logging without using tee and a separate process.

### DIFF
--- a/defaults/config/httpd/extra/httpd-logging.conf
+++ b/defaults/config/httpd/extra/httpd-logging.conf
@@ -1,4 +1,4 @@
-ErrorLog "|/usr/bin/tee"
+ErrorLog "/proc/self/fd/2"
 LogLevel info
 <IfModule log_config_module>
     LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
@@ -7,6 +7,6 @@ LogLevel info
     <IfModule logio_module>
       LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
     </IfModule>
-    CustomLog "|/usr/bin/tee" extended
+    CustomLog "/proc/self/fd/1" extended
 </IfModule>
 


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:  There's no need to spawn `tee` to handle logs.  HTTPD can be configured to write to stdout/stderr directly in the same way we configure php-fpm.

* An explanation of the use cases your change solves

Small optimization.  Saves the need to spawn `tee` proc twice in each container.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [n/a] I have added an integration test
