### PR TITLE
Set LD_LIBRARY_PATH when calling 'php' to list available modules.

### DIFF
--- a/lib/compile_helpers.py
+++ b/lib/compile_helpers.py
@@ -119,8 +119,11 @@ def _get_compiled_modules(ctx):
     output_to_skip = ['[PHP Modules]', '[Zend Modules]', '']
 
     php_binary = os.path.join(ctx["PHP_INSTALL_PATH"], 'bin', 'php')
+    env = {
+        'LD_LIBRARY_PATH': os.path.join(ctx["PHP_INSTALL_PATH"], 'lib')
+    }
 
-    process = subprocess.Popen([php_binary, '-m'], stdout=subprocess.PIPE)
+    process = subprocess.Popen([php_binary, '-m'], stdout=subprocess.PIPE, env=env)
     exit_code = process.wait()
     output = process.stdout.read().rstrip()
 


### PR DESCRIPTION
This is required so PHP can find any libraries it needs that are not packaged in the rootfs.

Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change: See above.

* An explanation of the use cases your change solves: If PHP is compiled against any libraries that are not included in the rootfs, ths command will fail.

Ex:

```
   Downloaded [https://s3.amazonaws.com/dmikusa-buildpack-tests/php-7.2.9-linux-x64.tgz] to [/tmp]
   /tmp/app/php/bin/php: error while loading shared libraries: libargon2.so.1: cannot open shared object file: No such file or directory
   Traceback (most recent call last):
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/scripts/compile.py", line 59, in <module>
       .from_build_pack('lib/additional_commands')
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/build_pack_utils/builder.py", line 209, in extensions
       process_extension(path, ctx, 'compile', process, args=[self])
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/build_pack_utils/utils.py", line 69, in process_extension
       success(getattr(extn, to_call)(*args))
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/extension_helpers.py", line 48, in extension_helper_wrapper
       return getattr(inst, 'compile')(install)
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/extension_helpers.py", line 154, in compile
       self._compile(install)
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/php/extension.py", line 142, in _compile
       validate_php_ini_extensions(ctx)
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/compile_helpers.py", line 165, in validate_php_ini_extensions
       all_supported =  _get_supported_php_extensions(ctx) + _get_compiled_modules(ctx)
     File "/tmp/buildpackdownloads/18e85629818c74c653bbfdfdb5c727a9/lib/compile_helpers.py", line 129, in _get_compiled_modules
       raise RuntimeError("Error determining PHP compiled modules")
   RuntimeError: Error determining PHP compiled modules
   Failed to compile droplet: Failed to run finalize script: exit status 1
   Exit status 223
```

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
