### PR TITLE
Check if proxy env is empty before adding the handler

### DIFF
--- a/lib/build_pack_utils/downloads.py
+++ b/lib/build_pack_utils/downloads.py
@@ -16,7 +16,7 @@ class Downloader(object):
     def _init_proxy(self):
         handlers = {}
         for key in self._ctx.keys():
-            if key.lower().endswith('_proxy'):
+            if key.lower().endswith('_proxy') and self._ctx[key]:
                 handlers[key.split('_')[0]] = self._ctx[key]
         self._log.debug('Loaded proxy handlers [%s]', handlers)
         openers = []


### PR DESCRIPTION
In cases where the variable is set but empty, the handler is added
and download may fail as urllib can't parse the host.

Integration tests otherwise might fail in this way (which does for us):
```
   Installing PHPMyAdmin 4.3.12
	
   Traceback (most recent call last):
	
     File "/tmp/buildpacks/5873ec426f9e706170c422f10ccc10a1/scripts/compile.py", line 59, in <module>
	
       .from_build_pack('lib/additional_commands')
	
     File "/tmp/buildpacks/5873ec426f9e706170c422f10ccc10a1/lib/build_pack_utils/builder.py", line 212, in extensions
	
       process_extension(path, ctx, 'compile', process, args=[self])
	
     File "/tmp/buildpacks/5873ec426f9e706170c422f10ccc10a1/lib/build_pack_utils/utils.py", line 69, in process_extension
	
       success(getattr(extn, to_call)(*args))
	
     File "/tmp/app/.extensions/phpmyadmin/extension.py", line 47, in compile
	
       strip=True)
	
     File "/tmp/buildpacks/5873ec426f9e706170c422f10ccc10a1/lib/build_pack_utils/cloudfoundry.py", line 176, in install_binary_direct
	
       self._dwn.custom_extension_download(url, url, fileToInstall)
	
     File "/tmp/buildpacks/5873ec426f9e706170c422f10ccc10a1/lib/build_pack_utils/downloads.py", line 46, in custom_extension_download
	
       res = urllib2.urlopen(url)
	
     File "/usr/lib64/python2.7/urllib2.py", line 154, in urlopen
	
       return opener.open(url, data, timeout)
	
     File "/usr/lib64/python2.7/urllib2.py", line 429, in open
	
       response = self._open(req, data)
	
     File "/usr/lib64/python2.7/urllib2.py", line 447, in _open
	
       '_open', req)
	
     File "/usr/lib64/python2.7/urllib2.py", line 407, in _call_chain
	
       result = func(*args)
	
     File "/usr/lib64/python2.7/urllib2.py", line 1241, in https_open
	
       context=self._context)
	
     File "/usr/lib64/python2.7/urllib2.py", line 1164, in do_open
	
       raise URLError('no host given')
	
   urllib2.URLError: <urlopen error no host given>
	
   Failed to compile droplet: Failed to run finalize script: exit status 1
	
   Exit status 223
	
   Cell diego-cell-4 stopping instance 81f7b182-ca9c-41e3-80fb-d50ef29d2e94
	
   Cell diego-cell-4 destroying container for instance 81f7b182-ca9c-41e3-80fb-d50ef29d2e94
	
   Cell diego-cell-4 successfully destroyed container for instance 81f7b182-ca9c-41e3-80fb-d50ef29d2e94
	
Error staging application: App staging failed in the buildpack compile phase
	
FAILED
```

This seems to be because the application has ```HTTP_PROXY``` and ```HTTPS_PROXY``` set in the environment, but they are empty string. The proposed change checks if the string is empty before registering the handler.

It can also be observed by debug logs:

```
   2019-02-11 14:54:37,023 [DEBUG] cloudfoundry - Using python downloader.
	
   2019-02-11 14:54:37,023 [DEBUG] downloads - Loaded proxy handlers [{'HTTP': '', 'https': '', 'no': '', 'NO': '', 'HTTPS': '', 'http': ''}]
```

After this patch, the output is the following:

```
   2019-02-12 12:37:57,007 [DEBUG] cloudfoundry - Using python downloader.
   2019-02-12 12:37:57,007 [DEBUG] downloads - Loaded proxy handlers [{}]
```

