### PR TITLE
Move the inclusion of php-fpm config snippets to the end of the php-fpm.conf file

### DIFF
--- a/defaults/config/php/7.1.x/php-fpm.conf
+++ b/defaults/config/php/7.1.x/php-fpm.conf
@@ -6,15 +6,6 @@
 ; prefix (/tmp/staged/app/php). This prefix can be dynamically changed by using the
 ; '-p' argument from the command line.
 
-; Include one or more files. If glob(3) exists, it is used to include a bunch of
-; files from a glob(3) pattern. This directive can be used everywhere in the
-; file.
-; Relative path can also be used. They will be prefixed by:
-;  - the global prefix if it's been set (-p argument)
-;  - /tmp/staged/app/php otherwise
-;include=@{HOME}/php/etc/fpm.d/*.conf
-#{PHP_FPM_CONF_INCLUDE}
-
 ;;;;;;;;;;;;;;;;;;
 ; Global Options ;
 ;;;;;;;;;;;;;;;;;;
@@ -521,3 +512,12 @@ clear_env = no
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p argument)
+;  - /tmp/staged/app/php otherwise
+;include=@{HOME}/php/etc/fpm.d/*.conf
+#{PHP_FPM_CONF_INCLUDE}

--- a/defaults/config/php/7.2.x/php-fpm.conf
+++ b/defaults/config/php/7.2.x/php-fpm.conf
@@ -6,15 +6,6 @@
 ; prefix (/tmp/staged/app/php). This prefix can be dynamically changed by using the
 ; '-p' argument from the command line.
 
-; Include one or more files. If glob(3) exists, it is used to include a bunch of
-; files from a glob(3) pattern. This directive can be used everywhere in the
-; file.
-; Relative path can also be used. They will be prefixed by:
-;  - the global prefix if it's been set (-p argument)
-;  - /tmp/staged/app/php otherwise
-;include=@{HOME}/php/etc/fpm.d/*.conf
-#{PHP_FPM_CONF_INCLUDE}
-
 ;;;;;;;;;;;;;;;;;;
 ; Global Options ;
 ;;;;;;;;;;;;;;;;;;
@@ -521,3 +512,12 @@ clear_env = no
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p argument)
+;  - /tmp/staged/app/php otherwise
+;include=@{HOME}/php/etc/fpm.d/*.conf
+#{PHP_FPM_CONF_INCLUDE}

--- a/defaults/config/php/7.3.x/php-fpm.conf
+++ b/defaults/config/php/7.3.x/php-fpm.conf
@@ -6,15 +6,6 @@
 ; prefix (/tmp/staged/app/php). This prefix can be dynamically changed by using the
 ; '-p' argument from the command line.
 
-; Include one or more files. If glob(3) exists, it is used to include a bunch of
-; files from a glob(3) pattern. This directive can be used everywhere in the
-; file.
-; Relative path can also be used. They will be prefixed by:
-;  - the global prefix if it's been set (-p argument)
-;  - /tmp/staged/app/php otherwise
-;include=@{HOME}/php/etc/fpm.d/*.conf
-#{PHP_FPM_CONF_INCLUDE}
-
 ;;;;;;;;;;;;;;;;;;
 ; Global Options ;
 ;;;;;;;;;;;;;;;;;;
@@ -521,3 +512,12 @@ clear_env = no
 ;php_admin_value[error_log] = /var/log/fpm-php.www.log
 ;php_admin_flag[log_errors] = on
 ;php_admin_value[memory_limit] = 32M
+
+; Include one or more files. If glob(3) exists, it is used to include a bunch of
+; files from a glob(3) pattern. This directive can be used everywhere in the
+; file.
+; Relative path can also be used. They will be prefixed by:
+;  - the global prefix if it's been set (-p argument)
+;  - /tmp/staged/app/php otherwise
+;include=@{HOME}/php/etc/fpm.d/*.conf
+#{PHP_FPM_CONF_INCLUDE}


### PR DESCRIPTION
This allows users to override all settings. See Issue #299.