### PR TITLE
Update post-deploy AppDynamics commands to include correct (updated) …

### DIFF
--- a/extensions/appdynamics/extension.py
+++ b/extensions/appdynamics/extension.py
@@ -211,10 +211,10 @@ class AppDynamicsInstaller(PHPExtensionHelper):
             [ 'echo "Installing AppDynamics package..."'],
             [ 'PHP_EXT_DIR=$(find /home/vcap/app -name "no-debug-non-zts*" -type d)'],
             [ 'chmod -R 755 /home/vcap'],
-            [ 'chmod -R 777 /home/vcap/app/appdynamics/appdynamics-php-agent/logs'],
+            [ 'chmod -R 777 /home/vcap/app/appdynamics/appdynamics-php-agent-linux_x64/logs'],
             [ 'if [ $APPD_CONF_SSL_ENABLED == \"true\" ] ; then export sslflag=-s ; '
               'echo sslflag set to $sslflag ; fi; '],
-            [ '/home/vcap/app/appdynamics/appdynamics-php-agent/install.sh '
+            [ '/home/vcap/app/appdynamics/appdynamics-php-agent-linux_x64/install.sh '
               '$sslflag '
               '-a "$APPD_CONF_ACCOUNT_NAME@$APPD_CONF_ACCESS_KEY" '
               '-e "$PHP_EXT_DIR" '

--- a/extensions/appdynamics/extension.py
+++ b/extensions/appdynamics/extension.py
@@ -51,7 +51,7 @@ class AppDynamicsInstaller(PHPExtensionHelper):
         """
         return {
                 'APPDYNAMICS_HOST': 'packages.appdynamics.com',
-                'APPDYNAMICS_VERSION': '4.5.2.2042',
+                'APPDYNAMICS_VERSION': '4.5.12.2925',
                 'APPDYNAMICS_PACKAGE': 'appdynamics-php-agent-linux_x64-{APPDYNAMICS_VERSION}.tar.bz2',
                 'APPDYNAMICS_DOWNLOAD_URL': 'https://{APPDYNAMICS_HOST}/php/{APPDYNAMICS_VERSION}/{APPDYNAMICS_PACKAGE}'
         }


### PR DESCRIPTION
…agent directory path.

This is a two line change that alters the targeted directory structure of the AppDynamics PHP agent. I dedicate any copyright to the public domain, and declare that all additions are not encumbered by any patents.

Without this change, all AppDynamics-enabled PHP pushes will fail.

Proof that I am kyle.furlong@appdynamics:
<img width="1136" alt="Screen Shot 2019-07-29 at 11 35 03" src="https://user-images.githubusercontent.com/16356/62073169-03c72f00-b1f5-11e9-926e-f23616ca3acf.png">

