### PR TITLE
Add psr to module list in fixtures

### DIFF
--- a/fixtures/php_72_all_modules/.bp-config/options.json
+++ b/fixtures/php_72_all_modules/.bp-config/options.json
@@ -49,6 +49,7 @@
     "phpiredis",
     "protobuf",
     "pspell",
+    "psr",
     "rdkafka",
     "readline",
     "recode",

--- a/fixtures/php_72_all_modules_composer/composer.json
+++ b/fixtures/php_72_all_modules_composer/composer.json
@@ -44,6 +44,7 @@
         "ext-phpiredis": "*",
         "ext-protobuf": "*",
         "ext-pspell": "*",
+        "ext-psr": "*",
         "ext-rdkafka": "*",
         "ext-readline": "*",
         "ext-recode": "*",


### PR DESCRIPTION
`phalcon` was bumped from 3.x to 4.x [here](https://github.com/cloudfoundry/php-buildpack/commit/5044a7887b0d3f1b6d325716463903ea2c71b84c) and it now depends on `psr` which was added [here](https://github.com/cloudfoundry/php-buildpack/commit/3af894df54131c82e7bfaf7c3e2a03ca632990ae). This commit adds it to the fixture apps to fix [this particular failure](https://buildpacks.ci.cf-app.com/teams/main/pipelines/php-buildpack/jobs/specs-edge-integration-develop/builds/754#L5f6ac0ea:427).