### PR TITLE
Add some modern day static extensions to the Nginx cache-control rule

### DIFF
--- a/defaults/config/nginx/server-locations.conf
+++ b/defaults/config/nginx/server-locations.conf
@@ -1,6 +1,6 @@
 
         # Some basic cache-control for static files to be sent to the browser
-        location ~* \.(?:ico|css|js|gif|jpeg|jpg|png)$ {
+        location ~* \.(?:ico|css|js|gif|jpeg|jpg|png|woff|woff2|svg)$ {
             expires         max;
             add_header      Pragma public;
             add_header      Cache-Control "public, must-revalidate, proxy-revalidate";


### PR DESCRIPTION
* I want to add the `.woff`, `.woff2` and `.svg` static file extensions to the Nginx cache-control rule
  (httpd doesn't seem to have such a rule, so no changes proposed there)

* This results in better cache for these files, besides the extensions that are already in this rule
  I am aware that the Nginx config can be overridden within projects, but I'd like to propose this as a change in the defaults so everyone can benefit this form these defaults.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
