### PR TITLE
Bumped libbuildpack-dynatrace to 1.4.1

### DIFF
--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -119,6 +119,8 @@ class DynatraceInstaller(object):
         self.create_folder(os.path.join(self._ctx['BUILD_DIR'], 'dynatrace'))
         installer = self._get_oneagent_installer_path()
         url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=php&include=nginx&include=apache'
+        if self._ctx['DYNATRACE_NETWORK_ZONE']:
+            url = url + f"&networkzone={self._ctx['DYNATRACE_NETWORK_ZONE']}"
         skiperrors = self._ctx['DYNATRACE_SKIPERRORS']
 
         try:

--- a/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
+++ b/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
@@ -165,4 +165,30 @@ var _ = Describe("Deploy app with", func() {
 		By("no further installer logs")
 		Expect(app.Stdout.String()).ToNot(ContainSubstring("Extracting Dynatrace OneAgent"))
 	})
+
+	Context("deploying a PHP app with Dynatrace agent with configured network zone", func() {
+		It("checks if networkzone setting was successful", func() {
+			serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			command := exec.Command("cf", "cups", serviceName, "-p", fmt.Sprintf("'{\"apitoken\":\"secretpaastoken\",\"apiurl\":\"%s\",\"environmentid\":\"envid\", \"networkzone\":\"testzone\"}'", dynatraceAPIURI))
+			_, err := command.CombinedOutput()
+			Expect(err).To(BeNil())
+			createdServices = append(createdServices, serviceName)
+
+			command = exec.Command("cf", "bind-service", app.Name, serviceName)
+			_, err = command.CombinedOutput()
+			Expect(err).To(BeNil())
+			command = exec.Command("cf", "restage", app.Name)
+			_, err = command.Output()
+			Expect(err).To(BeNil())
+
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace service credentials found. Setting up Dynatrace OneAgent."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Starting Dynatrace OneAgent installer"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Copy dynatrace-env.sh"))
+			Expect(app.Stdout.String()).To(ContainSubstring("Setting DT_NETWORK_ZONE..."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace OneAgent installed."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Dynatrace OneAgent injection is set up."))
+		})
+	})
+
 })


### PR DESCRIPTION
* A short explanation of the proposed change:
Bumped libbuildpack-dynatrace to 1.4.1 to include the networkzone parameter when downloading the OneAgent from the API
* An explanation of the use cases your change solves
This includes the networkzone parameter when downloading the OneAgent from the API
* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
