### PR TITLE
Fixed case of networkzone query parameter

### DIFF
--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -121,7 +121,7 @@ class DynatraceInstaller(object):
         url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=php&include=nginx&include=apache'
         if self._ctx['DYNATRACE_NETWORK_ZONE']:
             self._log.info("Setting DT_NETWORK_ZONE...")
-            url = url + ("&networkzone=%s" % self._ctx['DYNATRACE_NETWORK_ZONE'])
+            url = url + ("&networkZone=%s" % self._ctx['DYNATRACE_NETWORK_ZONE'])
         skiperrors = self._ctx['DYNATRACE_SKIPERRORS']
 
         try:


### PR DESCRIPTION
* A short explanation of the proposed change:
Fixed case of networkzone query parameter for Dynatrace OneAgent download
* An explanation of the use cases your change solves
The query parameter for the `networkzones` property had the wrong case. It was `networkzone` but it has to be `networkZone` with an upper-case Z.
This didn't cause any deployment problems, but the feature wasn't used as intended.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
