### PR TITLE
added update_agent_config() to Dynatrace extension 

### DIFF
--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -23,6 +23,7 @@ from subprocess import call
 import urllib2
 import json
 import time
+import re
 
 _log = logging.getLogger('dynatrace')
 
@@ -106,7 +107,8 @@ class DynatraceInstaller(object):
                 f.write(result.read())
                 f.close()
                 return
-            except IOError, exc:
+            # TODO change to 'err' if this is correct
+            except IOError as exc:
                 last_exception = exc
                 waittime = base_waittime + 2**attempt
                 _log.warn("Error during installer download, retrying in %s seconds" % (waittime))
@@ -127,7 +129,7 @@ class DynatraceInstaller(object):
         try:
             self._retry_download(url, installer)
             os.chmod(installer, 0o777)
-        except IOError, exc:
+        except IOError as exc:
             if skiperrors == 'true':
                 _log.warn('Error during installer download, skipping installation: %s' % (exc))
                 self._run_installer = False
@@ -188,6 +190,136 @@ class DynatraceInstaller(object):
         with open(envfile, "a") as file:
             file.write(extra_env)
 
+    # downloading the most recent OneAgent config from the configured tenants API,
+    # and merging it with the static config the standalone installer package brought along
+    def update_agent_config(self):
+
+        skiperrors = self._ctx['DYNATRACE_SKIPERRORS']
+        agent_config_url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/processmoduleconfig'
+
+        try:
+            # fetch most recent OneAgent config from tenant API
+            request = urllib2.Request(agent_config_url)
+            request.add_header("user-agent", "cf-php-buildpack/" + self.get_buildpack_version())
+            request.add_header("Authorization", "Api-Token {token}".format(token=self._ctx['DYNATRACE_TOKEN']))
+            result = urllib2.urlopen(request)
+        except IOError as err:
+            if skiperrors == 'true':
+                _log.warn('Error during agent config update, skipping it: %s'% (err))
+                return
+            else:
+                _log.error('ERROR: Failed to download most recent OneAgent config from API: %s '% (err))
+                raise
+        _log.debug("Successfully fetched OneAgent config from API")
+
+        # store fetched config in a nested dictionary for easy merging with
+        # the data from ruxitagentproc.conf
+        json_data = json.load(result)
+        config_from_api = dict()
+        for elem in json_data['properties']:
+            # Storing these values in individual variables might be a bit
+            # redundant, but it improves readability below.
+            # Also explicitly adding the braces for the sections we get via the
+            # the API, to have them formatted in the same ways as the ones from
+            # the ruxitagentproc.conf file
+            section = "[" + elem['section'] + "]"
+            key = elem['key']
+            value = elem['value']
+
+            # checking if the required dict is already there.
+            # if not: initialize it
+            if section not in config_from_api:
+                config_from_api[section] = dict()
+
+            config_from_api[section][key] = value
+
+
+        # read static config from standalone installer
+        try:
+            agent_config_path = os.path.join(
+                self._ctx['BUILD_DIR'],
+                'dynatrace',
+                'oneagent',
+                'agent',
+                'conf',
+                'ruxitagentproc.conf')
+            agent_config_file = open(agent_config_path, 'r')
+            agent_config_data = agent_config_file.readlines()
+            agent_config_file.close()
+        except IOERROR as err:
+            _log.error("ERROR: Failed to read OneAgent config file: %s" % (err))
+            raise
+
+        _log.debug("Successfully read OneAgent config from " + agent_config_path)
+
+        # store static config in same kind of data structure (nested dictionary)
+        # as we use for the config from we fetched from the API
+        section_regex = re.compile('\[(.*)\]')
+        config_section = ""
+        config_from_agent = dict()
+        _log.debug("Starting to parse OneAgent config...")
+        for line in agent_config_data:
+            line = line.rstrip()
+
+            if section_regex.match(line):
+                config_section = line
+                continue
+
+            if  line.startswith('#'):
+                # skipping over lines that are purely comments
+                continue
+            elif line == "":
+                # skipping over empty lines
+                continue
+
+            # store data in dict
+
+            # checking if the required dict is already there.
+            # if not: initialize it
+            if config_section not in config_from_agent:
+                config_from_agent[config_section] = dict()
+
+            config_line_key = line.split()[0]
+            rest_of_the_line = line.split()[1:]
+            # the join-construct is needed to convert the list, we get back from the slicing,
+            # into a proper string again.
+            #Otherwise we'd need to do the conversion whe writing the data back to the
+            # config file, which would be more cumbersome.
+            config_line_value = ' '.join(rest_of_the_line)
+            config_from_agent[config_section][config_line_key] = config_line_value
+        _log.debug("Successfully parsed OneAgent config...")
+
+        # Merging the two configs by just writing the contents we got from
+        # the API over the data we got from the local config file.
+        # This replaces existing values and adds new ones.
+        _log.debug("Starting with OneAgent configuration merging")
+        for section_name, section_content in config_from_api.items():
+            for key in section_content:
+                # checking if the required dict is already there.
+                # if not: initialize it
+                if section_name not in config_from_agent:
+                    config_from_agent[section_name] = dict()
+                config_from_agent[section_name][key] = config_from_api[section_name][key]
+        _log.debug("Finished OneAgent configuration merging")
+
+        # Write updated config back to ruxitagentproc.conf file
+        try:
+            overwrite_agent_config_file = open(agent_config_path, 'w')
+            for section_name, section_content in config_from_agent.items():
+                overwrite_agent_config_file.write(section_name + "\n")
+                for key in section_content:
+                    write_line = key + " " + section_content[key] + "\n"
+                    overwrite_agent_config_file.write(write_line)
+                # Trailing empty newline at the end of each section for better human readability
+                overwrite_agent_config_file.write("\n")
+            overwrite_agent_config_file.close()
+        except IOError as err:
+            _log.error("ERROR: Failed to write updated config to OneAgent config file: %s" % (err))
+            raise
+
+        _log.debug("Finished writing updated OneAgent config back to " + agent_config_path)
+
+
 
 # Extension Methods
 def compile(install):
@@ -204,4 +336,6 @@ def compile(install):
             dynatrace.adding_environment_variables()
             _log.info("Adding Dynatrace LD_PRELOAD settings")
             dynatrace.adding_ld_preload_settings()
+            _log.info("Fetching updated OneAgent configuration from tenant...")
+            dynatrace.update_agent_config()
     return 0

--- a/fixtures/fake_dynatrace_api/fake_config.json
+++ b/fixtures/fake_dynatrace_api/fake_config.json
@@ -1,0 +1,11 @@
+{
+  "revision":1234567890,
+  "properties":
+  [
+    {
+      "section":"fakesection",
+      "key":"fakekey",
+      "value":"fakevalue"
+    }
+  ]
+}

--- a/fixtures/fake_dynatrace_api/install.sh
+++ b/fixtures/fake_dynatrace_api/install.sh
@@ -12,6 +12,7 @@ function main() {
   curl -s --fail "http://{{.URI}}/manifest.json" > "${dir}/dynatrace/oneagent/manifest.json"
   curl -s --fail "http://{{.URI}}/dynatrace-env.sh" > "${dir}/dynatrace/oneagent/dynatrace-env.sh"
   curl -s --fail "http://{{.URI}}/liboneagentproc.so" > "${dir}/dynatrace/oneagent/agent/lib64/liboneagentproc.so"
+  curl -s --fail "http://{{.URI}}/ruxitagentproc.conf" > "${dir}/dynatrace/oneagent/agent/conf/ruxitagentproc.conf"
 }
 
 main "${@}"

--- a/fixtures/fake_dynatrace_api/main.go
+++ b/fixtures/fake_dynatrace_api/main.go
@@ -44,7 +44,7 @@ func main() {
 				return
 			}
 
-		case "/dynatrace-env.sh", "/liboneagentproc.so":
+		case "/dynatrace-env.sh", "/liboneagentproc.so", "/ruxitagentproc.conf":
 			contents, err := ioutil.ReadFile(strings.TrimPrefix(req.URL.Path, "/"))
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)

--- a/fixtures/fake_dynatrace_api/main.go
+++ b/fixtures/fake_dynatrace_api/main.go
@@ -79,6 +79,16 @@ func main() {
 
 			json.NewEncoder(w).Encode(payload)
 
+		case "/v1/deployment/installer/agent/processmoduleconfig":
+			fakeConfig, err := ioutil.ReadFile("fake_config.json")
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			w.Write(fakeConfig)
+
+
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
+++ b/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
@@ -180,4 +180,19 @@ var _ = Describe("Deploy app with", func() {
 		})
 	})
 
+	Context("deploying a PHP app with Dynatrace OneAgent with configured network zone", func() {
+		It("checks if agent config update via API was successful", func() {
+			serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+			Expect(RunCf("cups", serviceName, "-p", fmt.Sprintf(`{"apitoken":"secretpaastoken","apiurl":"%s","environmentid":"envid", "networkzone":"testzone"}`, dynatraceAPIURI))).To(Succeed())
+			Expect(RunCf("bind-service", app.Name, serviceName)).To(Succeed())
+			Expect(RunCf("start", app.Name)).To(Succeed())
+			ConfirmRunning(app)
+
+			// we want to see the update in the config
+			Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+			Expect(app.Stdout.String()).To(ContainSubstring("Fetching updated OneAgent configuration from tenant..."))
+			Expect(app.Stdout.String()).To(ContainSubstring("Finished writing updated OneAgent config back to"))
+		})
+	})
+
 })


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
Added the functionality to fetch the most recent OneAgent configuration from the configured Dynatrace tenant during deployment.

* An explanation of the use cases your change solves
This enables users of the php-buildpack who are using Dynatrace to instrument their apps to update OneAgent settings with a simple restaging of a given CloudFoundry app

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
