### PR TITLE
BYO python and introduce cflinuxfs4 support

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -21,12 +21,14 @@
 #  build pack needs to do anything to bootstrap the
 #  python scripts, like install Python.
 BP=$(dirname $(dirname $0))
+
 # Install python if stack is cflinuxfs4 so its available during staging
 if [ "$CF_STACK" == "cflinuxfs4" ]; then
   PYTHON_DIR="/tmp/python"
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
 fi
+
 export PYTHONPATH=$BP/lib
 VERSION=`cat $BP/VERSION`
 python2 $BP/scripts/detect.py $1 $VERSION

--- a/bin/detect
+++ b/bin/detect
@@ -21,6 +21,12 @@
 #  build pack needs to do anything to bootstrap the
 #  python scripts, like install Python.
 BP=$(dirname $(dirname $0))
+# Install python if stack is cflinuxfs4 so its available during staging
+if [ "$CF_STACK" == "cflinuxfs4" ]; then
+  PYTHON_DIR="/tmp/python"
+  mkdir -p "${PYTHON_DIR}"
+  source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
+fi
 export PYTHONPATH=$BP/lib
 VERSION=`cat $BP/VERSION`
 python2 $BP/scripts/detect.py $1 $VERSION

--- a/bin/finalize
+++ b/bin/finalize
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+shopt -s expand_aliases
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -21,13 +22,18 @@ set -e
 #  python script.  However, this is here in case the
 #  build pack needs to do anything to bootstrap the
 #  python scripts, like install Python.
-BP=$(dirname $(dirname $0))
 
+BP=$(dirname $(dirname $0))
 BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 DEPS_DIR=${3:-}
 DEPS_IDX=${4:-}
 PROFILE_DIR=${5:-}
+
+# Install python if stack is cflinuxfs4 so its available during staging and build
+if [ "$CF_STACK" == "cflinuxfs4" ]; then
+  source "$BP/bin/install-python" "$DEPS_DIR/$DEPS_IDX" "$BP"
+fi
 
 BUILDPACK_PATH=$BP
 export BUILDPACK_PATH

--- a/bin/finalize
+++ b/bin/finalize
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-shopt -s expand_aliases
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/bin/install-python
+++ b/bin/install-python
@@ -6,18 +6,21 @@ function main() {
   install_dir="$1"
   buildpack_dir="$2"
 
-  python_dep_name=$(get_python_from_manifest "$buildpack_dir")
-  echo "-------> Providing Python $(echo $python_dep_name | cut -d'_' -f 2) (required by the buildpack to run in cflinuxfs4)"
+  if [ ! -d "/tmp/python/bin" ]; then
+    python_dep_name=$(get_python_from_manifest "$buildpack_dir")
+    echo "-------> Providing Python $(echo $python_dep_name | cut -d'_' -f 2) (required by the buildpack to run in cflinuxfs4)"
 
-  if [ ! -d "$buildpack_dir/dependencies" ]; then
-    setup_online "$python_dep_name" "$install_dir" "$buildpack_dir"
-  else
-    setup_offline "$python_dep_name" "$install_dir" "$buildpack_dir"
+    if [ ! -d "$buildpack_dir/dependencies" ]; then
+      setup_online "$python_dep_name" "$install_dir" "$buildpack_dir"
+    else
+      setup_offline "$python_dep_name" "$install_dir" "$buildpack_dir"
+    fi
+  elif [ $install_dir != "/tmp/python" ]; then
+    cp -r "/tmp/python/." "$install_dir"
   fi
 
   export LD_LIBRARY_PATH="$install_dir/lib:/lib"
   export PATH="$install_dir/bin:${PATH:-}"
-
   alias python2=python2.7
 }
 

--- a/bin/install-python
+++ b/bin/install-python
@@ -19,7 +19,7 @@ function main() {
     cp -r "/tmp/python/." "$install_dir"
   fi
 
-  export LD_LIBRARY_PATH="$install_dir/lib:/lib"
+  export LD_LIBRARY_PATH="$install_dir/lib:${LD_LIBRARY_PATH:-}"
   export PATH="$install_dir/bin:${PATH:-}"
   alias python2=python2.7
 }

--- a/bin/install-python
+++ b/bin/install-python
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+shopt -s expand_aliases
+
+function main() {
+  install_dir="$1"
+  buildpack_dir="$2"
+
+  python_dep_name=$(get_python_from_manifest "$buildpack_dir")
+  echo "-------> Providing Python $(echo $python_dep_name | cut -d'_' -f 2) (required by the buildpack to run in cflinuxfs4)"
+
+  if [ ! -d "$buildpack_dir/dependencies" ]; then
+    setup_online "$python_dep_name" "$install_dir" "$buildpack_dir"
+  else
+    setup_offline "$python_dep_name" "$install_dir" "$buildpack_dir"
+  fi
+
+  export LD_LIBRARY_PATH="$install_dir/lib:/lib"
+  export PATH="$install_dir/bin:${PATH:-}"
+
+  alias python2=python2.7
+}
+
+function setup_offline() {
+  python_dep_name="$1"
+  install_dir="$2"
+  buildpack_dir="$3"
+
+  tar -xzf "$buildpack_dir/dependencies/https___buildpacks.cloudfoundry.org_dependencies_python_$python_dep_name" -C "$install_dir"
+}
+
+function setup_online(){
+  python_dep_name="$1"
+  install_dir="$2"
+  buildpack_dir="$3"
+
+  curl -Ls "https://buildpacks.cloudfoundry.org/dependencies/python/$python_dep_name" | tar -xzf - -C "$install_dir"
+}
+
+function get_python_from_manifest() {
+  buildpack_dir="$1"
+  python_dep_info=$(cat "$buildpack_dir/manifest.yml" | grep -A 3 "name: python" | grep "uri:" | awk '{print $2}' | cut -d'/' -f 6)
+  echo "$python_dep_info"
+}
+
+main "${@:-}"

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -21,6 +22,15 @@
 #  build pack needs to do anything to bootstrap the
 #  python scripts, like install Python.
 BP=$(dirname $(dirname $0))
+
+# Install python if stack is cflinuxfs4 so its available during staging
+if [ "$CF_STACK" == "cflinuxfs4" ]; then
+  PYTHON_DIR="/tmp/python"
+  mkdir -p "${PYTHON_DIR}"
+  source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
+fi
+
+
 export PYTHONPATH=$BP/lib
 
 python2 $BP/scripts/release.py $1

--- a/cf.Gemfile
+++ b/cf.Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-ruby '~> 2.3'
+ruby '~> 3.0'
 
-gem 'buildpack-packager', git: 'https://github.com/cloudfoundry/buildpack-packager', tag: 'v2.3.22'
+gem 'buildpack-packager', git: 'https://github.com/cloudfoundry/buildpack-packager', tag: 'v2.3.23'

--- a/cf.Gemfile.lock
+++ b/cf.Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/cloudfoundry/buildpack-packager
-  revision: 080f6fb773bf151dfae87a22d6852749d6be968a
-  tag: v2.3.22
+  revision: f88bfee41cf46d5b6ea487d6c30a99ed7c0e51eb
+  tag: v2.3.23
   specs:
-    buildpack-packager (2.3.22)
+    buildpack-packager (2.3.23)
       activesupport (~> 4.1)
       kwalify (~> 0)
       semantic
@@ -37,7 +37,7 @@ DEPENDENCIES
   buildpack-packager!
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 3.0.5p211
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/manifest.yml
+++ b/manifest.yml
@@ -55,6 +55,13 @@ dependency_deprecation_dates:
   link: http://php.net/supported-versions.php
   match: 8.2.\d+
 dependencies:
+- name: python
+  version: 2.7.18
+  uri: https://buildpacks.cloudfoundry.org/dependencies/python/python_2.7.18_linux_x64_cflinuxfs4_4454dcd.tgz
+  sha256: 4454dcd542031cdc3b839def90f5cad06ac2ed2cacddf3a209b3c0ab13904fc3
+  cf_stacks:
+  - cflinuxfs4
+  source_sha256: 4454dcd542031cdc3b839def90f5cad06ac2ed2cacddf3a209b3c0ab13904fc3
 - name: appdynamics
   version: 22.12.1-677
   uri: https://download.run.pivotal.io/appdynamics-php/appdynamics-22.12.1-677.tar.bz2
@@ -95,6 +102,7 @@ dependencies:
   sha256: '0095809b1a7e405d5aac675661df837a399d605bb9e515e1ce8c7e255279b9a3'
   cf_stacks:
   - cflinuxfs3
+  - cflinuxfs4
   osl: https://docs.newrelic.com/docs/licenses/license-information/agent-licenses/java-agent-licenses
 - name: nginx
   version: 1.22.1

--- a/scripts/.util/print.sh
+++ b/scripts/.util/print.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+function util::print::title() {
+  local blue reset message
+  blue="\033[0;34m"
+  reset="\033[0;39m"
+  message="${1}"
+
+  echo -e "\n${blue}${message}${reset}" >&2
+}
+
+function util::print::info() {
+  local message
+  message="${1}"
+
+  echo -e "${message}" >&2
+}
+
+function util::print::error() {
+  local message red reset
+  message="${1}"
+  red="\033[0;31m"
+  reset="\033[0;39m"
+
+  echo -e "${red}${message}${reset}" >&2
+  exit 1
+}
+
+function util::print::success() {
+  local message green reset
+  message="${1}"
+  green="\033[0;32m"
+  reset="\033[0;39m"
+
+  echo -e "${green}${message}${reset}" >&2
+  exitcode="${2:-0}"
+  exit "${exitcode}"
+}
+
+function util::print::warn() {
+  local message yellow reset
+  message="${1}"
+  yellow="\033[0;33m"
+  reset="\033[0;39m"
+
+  echo -e "${yellow}${message}${reset}" >&2
+  exit 0
+}
+

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+ROOTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly ROOTDIR
+
+## shellcheck source=SCRIPTDIR/.util/tools.sh
+#source "${ROOTDIR}/scripts/.util/tools.sh"
+#
+# shellcheck source=SCRIPTDIR/.util/print.sh
+source "${ROOTDIR}/scripts/.util/print.sh"
+
+function main() {
+  local stack version cached output
+  stack="any"
+  cached="false"
+  output="${ROOTDIR}/build/buildpack.zip"
+
+  while [[ "${#}" != 0 ]]; do
+    case "${1}" in
+      --stack)
+        stack="${2}"
+        shift 2
+        ;;
+
+      --cached)
+        cached="true"
+        shift 1
+        ;;
+
+      --uncached)
+        cached="false"
+        shift 1
+        ;;
+
+      --help|-h)
+        shift 1
+        usage
+        exit 0
+        ;;
+
+      "")
+        # skip if the argument is empty
+        shift 1
+        ;;
+
+      *)
+        util::print::error "unknown argument \"${1}\""
+    esac
+  done
+
+  package::buildpack "${cached}" "${stack}"
+}
+
+
+function usage() {
+  cat <<-USAGE
+package.sh [OPTIONS]
+Packages the buildpack into a .zip file.
+OPTIONS
+  --help               -h            prints the command usage
+  --cached            packages the buildpack as a cached buildpack
+  --uncached          packages the buildpack as an uncached buildpack (default)
+  --stack             the stack to package the buildpack for (default: any)
+USAGE
+}
+
+function package::buildpack() {
+  local cached stack
+  cached="${1}"
+  stack="${2}"
+
+
+  local stack_flag
+  stack_flag="--any-stack"
+  if [[ "${stack}" != "any" ]]; then
+    stack_flag="--stack=${stack}"
+  fi
+
+  local cached_flag
+  cached_flag="--uncached"
+  if [[ "${cached}" == "true" ]]; then
+    cached_flag="--cached"
+  fi
+
+  pushd "${ROOTDIR}" &> /dev/null
+    cat <<EOF > Dockerfile
+FROM ruby:3.0
+RUN apt-get update && apt-get install -y zip
+ADD cf.Gemfile .
+ADD cf.Gemfile.lock .
+ENV BUNDLE_GEMFILE=cf.Gemfile
+RUN bundle install
+ENTRYPOINT ["bundle", "exec", "buildpack-packager"]
+EOF
+    docker build -t buildpack-packager . &> /dev/null
+
+    echo "Running buildpack-packager with flags: ${stack_flag} ${cached_flag}"
+    docker run --rm -v ${ROOTDIR}:/buildpack -w /buildpack buildpack-packager ${stack_flag} ${cached_flag} &> /dev/null
+    util::print::success "Buildpack packaged successfully"
+
+    rm Dockerfile
+  popd &> /dev/null
+}
+
+main "${@:-}"


### PR DESCRIPTION
WIP #814 and #780 

- Enable buildpack to run on cflinuxfs4
  - The buildpack will install Python 2 when using cflinuxfs4 as the stack
  - This works in both the offline and online case
- Update Gemfile and Gemfile.lock to use Ruby 3.0
- Add a package script to simplify buildpack packaging, which uses buildpack-packager under the hood
