### PR TITLE
BYO ruby

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -27,6 +27,10 @@ if [ "$CF_STACK" == "cflinuxfs4" ]; then
   PYTHON_DIR="/tmp/python"
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
+
+  RUBY_DIR="/tmp/ruby"
+  mkdir -p "${RUBY_DIR}"
+  source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
 fi
 
 export PYTHONPATH=$BP/lib

--- a/bin/finalize
+++ b/bin/finalize
@@ -32,6 +32,7 @@ PROFILE_DIR=${5:-}
 # Install python if stack is cflinuxfs4 so its available during staging and build
 if [ "$CF_STACK" == "cflinuxfs4" ]; then
   source "$BP/bin/install-python" "$DEPS_DIR/$DEPS_IDX" "$BP"
+  source "$BP/bin/install-ruby" "$DEPS_DIR/$DEPS_IDX" "$BP"
 fi
 
 BUILDPACK_PATH=$BP

--- a/bin/install-ruby
+++ b/bin/install-ruby
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e
+shopt -s expand_aliases
+
+function main() {
+  local install_dir="$1"
+  local buildpack_dir="$2"
+  local ruby_dep_name=$(get_ruby_from_manifest "$buildpack_dir")
+
+  if [[ ! -d "/tmp/ruby/bin" ]]; then
+    setup_ruby "$ruby_dep_name" "$install_dir" "$buildpack_dir"
+  elif [[ $install_dir != "/tmp/ruby" ]]; then
+    cp -r "/tmp/ruby/." "$install_dir"
+  fi
+  export PATH="$install_dir/bin:${PATH:-}"
+  alias ruby=ruby3
+}
+
+function setup_ruby() {
+  local ruby_dep_name="$1"
+  local install_dir="$2"
+  local buildpack_dir="$3"
+
+  if [[ -d "$buildpack_dir/dependencies" ]]; then
+    tar -xzf "$buildpack_dir/dependencies/https___buildpacks.cloudfoundry.org_dependencies_ruby_$ruby_dep_name" -C "$install_dir"
+  else
+    curl -Ls "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.0.5_linux_x64_cflinuxfs3_098393c3.tgz" | tar -xzf - -C "$install_dir"
+  fi
+}
+
+function get_ruby_from_manifest() {
+  local buildpack_dir="$1"
+  grep -A 3 "name: ruby" < "$buildpack_dir/manifest.yml" | awk '/uri:/ {print $2}' | cut -d'/' -f 6
+}
+
+main "${@:-}"

--- a/bin/release
+++ b/bin/release
@@ -24,10 +24,15 @@ set -e
 BP=$(dirname "$(dirname "$0")")
 
 # Install python if stack is cflinuxfs4 so its available during staging
+# Install ruby if stack is cflinuxfs4 so its available during staging
 if [ "$CF_STACK" == "cflinuxfs4" ]; then
   PYTHON_DIR="/tmp/python"
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
+
+  RUBY_DIR="/tmp/ruby"
+  mkdir -p "${RUBY_DIR}"
+  source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
 fi
 
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1396,3 +1396,11 @@ dependencies:
   cf_stacks:
   - cflinuxfs4
   source_sha256: 4454dcd542031cdc3b839def90f5cad06ac2ed2cacddf3a209b3c0ab13904fc3
+- name: ruby
+  version: 3.0.5
+  uri: https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.0.5_linux_x64_cflinuxfs3_098393c3.tgz
+  sha256: '098393c33a20af7638ff7183bbf184daf9b207b31e39f20a7fd00466823859b3'
+  cf_stacks:
+  - cflinuxfs4
+  source: https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.5.tar.gz
+  source_sha256: 9afc6380a027a4fe1ae1a3e2eccb6b497b9c5ac0631c12ca56f9b7beb4848776


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:

Buildpack will now install its own Ruby dependency needed for the build. Similarly to #815, with the removal of `ruby` from cflinuxfs4, we need to also provide Ruby so that its accessible for the bits of the buildpack that need it. In the long-term we should remove the necessity to have Ruby in this buildpack.

I reproduced the error in the CATs related to ruby (https://github.com/cloudfoundry/cf-acceptance-tests/blob/af5ab9b193db43c330ac52fb69cca51b802b8037/detect/buildpacks.go#L133-L157) and this fix has resulted in a successful build.

* An explanation of the use cases your change solves
#849 

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have added an integration test
