### PR TITLE
bump integration test disk size with recent addition of byo ruby

### DIFF
--- a/src/php/integration/integration_suite_test.go
+++ b/src/php/integration/integration_suite_test.go
@@ -35,7 +35,7 @@ func init() {
 	flag.StringVar(&buildpackVersion, "version", "", "version to use (builds if empty)")
 	flag.BoolVar(&cutlass.Cached, "cached", true, "cached buildpack")
 	flag.StringVar(&cutlass.DefaultMemory, "memory", "256M", "default memory for pushed apps")
-	flag.StringVar(&cutlass.DefaultDisk, "disk", "500M", "default disk for pushed apps")
+	flag.StringVar(&cutlass.DefaultDisk, "disk", "750M", "default disk for pushed apps")
 	flag.StringVar(&stack, "stack", "cflinuxfs3", "stack to use when pushing apps")
 	flag.Parse()
 }


### PR DESCRIPTION
Bump integration disk size up, since we are now hitting disk limits in our CI tests due to the introduction of the Ruby dependency during the build.