### PR TITLE
Install bootstrapped Ruby into php-buildpack specific location

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -28,7 +28,7 @@ if [ "$CF_STACK" == "cflinuxfs4" ]; then
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
 
-  RUBY_DIR="/tmp/ruby"
+  RUBY_DIR="/tmp/php-buildpack/ruby"
   mkdir -p "${RUBY_DIR}"
   source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
 fi

--- a/bin/install-ruby
+++ b/bin/install-ruby
@@ -8,10 +8,10 @@ function main() {
   local buildpack_dir="$2"
   local ruby_dep_name=$(get_ruby_from_manifest "$buildpack_dir")
 
-  if [[ ! -d "/tmp/ruby/bin" ]]; then
+  if [[ ! -d "/tmp/php-buildpack/ruby/bin" ]]; then
     setup_ruby "$ruby_dep_name" "$install_dir" "$buildpack_dir"
-  elif [[ $install_dir != "/tmp/ruby" ]]; then
-    cp -r "/tmp/ruby/." "$install_dir"
+  elif [[ $install_dir != "/tmp/php-buildpack/ruby" ]]; then
+    cp -r "/tmp/php-buildpack/ruby/." "$install_dir"
   fi
   export PATH="$install_dir/bin:${PATH:-}"
   alias ruby=ruby3

--- a/bin/release
+++ b/bin/release
@@ -30,7 +30,7 @@ if [ "$CF_STACK" == "cflinuxfs4" ]; then
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
 
-  RUBY_DIR="/tmp/ruby"
+  RUBY_DIR="/tmp/php-buildpack/ruby"
   mkdir -p "${RUBY_DIR}"
   source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
 fi


### PR DESCRIPTION
- This avoids clashing with existing ruby installations provided by other buildpacks, which are typically different versions of ruby than required by this buildpack.

* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have added an integration test
