### PR TITLE
bump default nginx version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -22,7 +22,7 @@ default_versions:
 - name: newrelic
   version: 10.6.0.318
 - name: nginx
-  version: 1.23.3
+  version: 1.23.4
 - name: composer
   version: 2.5.5
 url_to_dependency_map:


### PR DESCRIPTION
Thanks for contributing to the buildpack. To speed up the process of reviewing your pull request please provide us with:

* A short explanation of the proposed change:
in #857 we bumped the Nginx version, but failed to bump the default version in the manifest as well.

* An explanation of the use cases your change solves

* [X] I have viewed signed and have submitted the Contributor License Agreement

* [X] I have made this pull request to the `develop` branch

* [ ] I have added an integration test