### PR TITLE
manifest.yml: don't ship requirements.txt only used in unit test

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,6 +13,7 @@ exclude_files:
 - cf.Gemfile.lock
 - bin/package
 - buildpack-packager/
+- requirements.txt
 - php_buildpack-*v*
 default_versions:
 - name: php


### PR DESCRIPTION
Also lets scanners avoid https://nvd.nist.gov/vuln/detail/CVE-2021-27291
