### PR TITLE
Fix unit tests

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,7 @@ default_versions:
 - name: newrelic
   version: 10.6.0.318
 - name: nginx
-  version: 1.25.0
+  version: 1.25.1
 - name: composer
   version: 2.5.8
 url_to_dependency_map:

--- a/src/php/unit/python_unit_specs_test.go
+++ b/src/php/unit/python_unit_specs_test.go
@@ -19,7 +19,7 @@ var _ = Describe("python unit tests", func() {
 
 		var cmd *exec.Cmd
 		if IsDockerAvailable() {
-			image := "cloudfoundry/cflinuxfs3"
+			image := "cloudfoundry/cflinuxfs3:0.356.0"
 
 			err = exec.Command("docker", "pull", image).Run()
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
# Context

In the unit tests, cflinuxfs3 is used to run the tests (the latest tag is used). This is generating error due to a problem between the libraries to install, specifically with `python-dev`, generating the following error:

```bash
The following packages have unmet dependencies:
 python-dev : Depends: libpython-dev (= 2.7.15~rc1-1) but it is not going to be installed.
              Depends: python2.7-dev (>= 2.7.15~rc1-1~) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

So I made a pin from the last image tag that works and installs the required dependency. This problem has a bigger background and that is that we should start the official migration process of cflinuxfs3 in all our pipelines since it is deprecated.
