### PR TITLE
install-ruby/py scripts: don't grep around, pick the pattern

### DIFF
--- a/bin/install-python
+++ b/bin/install-python
@@ -33,7 +33,7 @@ function setup_python() {
 
 function get_python_from_manifest() {
   local buildpack_dir="$1"
-  grep -A 3 "name: python" < "$buildpack_dir/manifest.yml" | awk '/uri:/ {print $2}' | cut -d'/' -f 6
+  cat "$buildpack_dir/manifest.yml" | awk '/uri:/ && /\/python\// {print}' | sed 's:.*/::'
 }
 
 main "${@:-}"

--- a/bin/install-ruby
+++ b/bin/install-ruby
@@ -31,7 +31,7 @@ function setup_ruby() {
 
 function get_ruby_from_manifest() {
   local buildpack_dir="$1"
-  grep -A 3 "name: ruby" < "$buildpack_dir/manifest.yml" | awk '/uri:/ {print $2}' | cut -d'/' -f 6
+  cat "$buildpack_dir/manifest.yml" | awk '/uri:/ && /\/ruby\// {print}' | sed 's:.*/::'
 }
 
 main "${@:-}"


### PR DESCRIPTION
since we will only have 1 ruby and 1 python dependency.

Fixes #885