### PR TITLE
Remove check on cflinuxfs4 when bootstrapping ruby and python.

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -22,16 +22,13 @@
 #  python scripts, like install Python.
 BP=$(dirname "$(dirname "$0")")
 
-# Install python if stack is cflinuxfs4 so its available during staging
-if [ "$CF_STACK" == "cflinuxfs4" ]; then
-  PYTHON_DIR="/tmp/php-buildpack/python"
-  mkdir -p "${PYTHON_DIR}"
-  source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
+PYTHON_DIR="/tmp/php-buildpack/python"
+mkdir -p "${PYTHON_DIR}"
+source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
 
-  RUBY_DIR="/tmp/php-buildpack/ruby"
-  mkdir -p "${RUBY_DIR}"
-  source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
-fi
+RUBY_DIR="/tmp/php-buildpack/ruby"
+mkdir -p "${RUBY_DIR}"
+source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
 
 export PYTHONPATH=$BP/lib
 VERSION="$(cat "$BP"/VERSION)"

--- a/bin/finalize
+++ b/bin/finalize
@@ -29,11 +29,8 @@ DEPS_DIR=${3:-}
 DEPS_IDX=${4:-}
 PROFILE_DIR=${5:-}
 
-# Install python if stack is cflinuxfs4 so its available during staging and build
-if [ "$CF_STACK" == "cflinuxfs4" ]; then
-  source "$BP/bin/install-python" "$DEPS_DIR/$DEPS_IDX" "$BP"
-  source "$BP/bin/install-ruby" "$DEPS_DIR/$DEPS_IDX" "$BP"
-fi
+source "$BP/bin/install-python" "$DEPS_DIR/$DEPS_IDX" "$BP"
+source "$BP/bin/install-ruby" "$DEPS_DIR/$DEPS_IDX" "$BP"
 
 BUILDPACK_PATH=$BP
 export BUILDPACK_PATH

--- a/bin/release
+++ b/bin/release
@@ -23,18 +23,13 @@ set -e
 #  python scripts, like install Python.
 BP=$(dirname "$(dirname "$0")")
 
-# Install python if stack is cflinuxfs4 so its available during staging
-# Install ruby if stack is cflinuxfs4 so its available during staging
-if [ "$CF_STACK" == "cflinuxfs4" ]; then
-  PYTHON_DIR="/tmp/php-buildpack/python"
-  mkdir -p "${PYTHON_DIR}"
-  source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
+PYTHON_DIR="/tmp/php-buildpack/python"
+mkdir -p "${PYTHON_DIR}"
+source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null
 
-  RUBY_DIR="/tmp/php-buildpack/ruby"
-  mkdir -p "${RUBY_DIR}"
-  source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
-fi
-
+RUBY_DIR="/tmp/php-buildpack/ruby"
+mkdir -p "${RUBY_DIR}"
+source "$BP/bin/install-ruby" "$RUBY_DIR" "$BP" &> /dev/null
 
 export PYTHONPATH=$BP/lib
 


### PR DESCRIPTION
- There is no disadvantage to running this bootstrap process on all stacks, and this change makes the buildpack work on any stack, regardless of whether ruby/python are present on the stack or not.

See also https://github.com/cloudfoundry/java-buildpack/pull/1017 for a similar change on the Java buildpack.
* [x] I have viewed signed and have submitted the Contributor License Agreement
* [x] I have made this pull request to the `develop` branch
* [ ] I have added an integration test
