### PR TITLE
Bootstrap only on cflinuxfs3

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -22,8 +22,10 @@
 #  python scripts, like install Python.
 BP=$(dirname "$(dirname "$0")")
 
-# Install python if stack is cflinuxfs4 so its available during staging
-if [ "$CF_STACK" == "cflinuxfs4" ]; then
+# Generally stacks do not have ruby or python installed, with the exception of cflinuxfs3, so we install them here
+# We deliberately skip re-installing python and ruby on the cflinuxfs3 stack to avoid compatibility issues
+# (e.g. the bootstrapped python is incompatible with cflinuxfs3 due to being compiled on a newer version of GBLIC)
+if [ "$CF_STACK" != "cflinuxfs3" ]; then
   PYTHON_DIR="/tmp/php-buildpack/python"
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null

--- a/bin/finalize
+++ b/bin/finalize
@@ -29,8 +29,10 @@ DEPS_DIR=${3:-}
 DEPS_IDX=${4:-}
 PROFILE_DIR=${5:-}
 
-# Install python if stack is cflinuxfs4 so its available during staging and build
-if [ "$CF_STACK" == "cflinuxfs4" ]; then
+# Generally stacks do not have ruby or python installed, with the exception of cflinuxfs3, so we install them here
+# We deliberately skip re-installing python and ruby on the cflinuxfs3 stack to avoid compatibility issues
+# (e.g. the bootstrapped python is incompatible with cflinuxfs3 due to being compiled on a newer version of GBLIC)
+if [ "$CF_STACK" != "cflinuxfs3" ]; then
   source "$BP/bin/install-python" "$DEPS_DIR/$DEPS_IDX" "$BP"
   source "$BP/bin/install-ruby" "$DEPS_DIR/$DEPS_IDX" "$BP"
 fi

--- a/bin/release
+++ b/bin/release
@@ -23,9 +23,10 @@ set -e
 #  python scripts, like install Python.
 BP=$(dirname "$(dirname "$0")")
 
-# Install python if stack is cflinuxfs4 so its available during staging
-# Install ruby if stack is cflinuxfs4 so its available during staging
-if [ "$CF_STACK" == "cflinuxfs4" ]; then
+# Generally stacks do not have ruby or python installed, with the exception of cflinuxfs3, so we install them here
+# We deliberately skip re-installing python and ruby on the cflinuxfs3 stack to avoid compatibility issues
+# (e.g. the bootstrapped python is incompatible with cflinuxfs3 due to being compiled on a newer version of GBLIC)
+if [ "$CF_STACK" != "cflinuxfs3" ]; then
   PYTHON_DIR="/tmp/php-buildpack/python"
   mkdir -p "${PYTHON_DIR}"
   source "$BP/bin/install-python" "$PYTHON_DIR" "$BP" &> /dev/null


### PR DESCRIPTION
In #896 we tried to remove the bootstrapping check on `cflinuxfs4`, but that resulted in the buildpack failing on `cflinuxfs3` due to an incompatibility between the bootstrapped version of python and the `cflinuxfs3` stack.

In general, it seems fair to assume that:
1. stacks won't have ruby/python
2. stacks are new enough to support the bootstrapped ruby/python.

The only stack that doesn't meet both of those criteria is the `cflinuxfs3` stack, so we treat it as the special case, and skip the bootstrapping.