### PR TITLE
Add fixtures to .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "compile-extensions"]
 	path = compile-extensions
 	url = https://github.com/cloudfoundry/compile-extensions
+[submodule "fixtures/composer_no_index_dot_php/vendor/monolog/monolog"]
+	path = fixtures/composer_no_index_dot_php/vendor/monolog/monolog
+	url = https://github.com/Seldaek/monolog
+[submodule "fixtures/composer_no_index_dot_php/vendor/psr/log"]
+	path = fixtures/composer_no_index_dot_php/vendor/psr/log
+	url = https://github.com/php-fig/log


### PR DESCRIPTION
* A short explanation of the proposed change:
Add recently added submodules to `.gitmodules` file.

* An explanation of the use cases your change solves
Command `git submodule update --init` fails with following message: 
`No url found for submodule path 'fixtures/composer_no_index_dot_php/vendor/monolog/monolog' in .gitmodules`.
It happens because in a recent commit `d93f6570566b249ec7845568a52cde6d3c76104d` two directories were updated as external repos, but these repos weren't added to a `.gitmodules` file.
