### PR TITLE
Remove dependency credential test

### DIFF
--- a/src/php/brats/brats_test.go
+++ b/src/php/brats/brats_test.go
@@ -15,7 +15,6 @@ var _ = Describe("PHP buildpack", func() {
 	bratshelper.DeployingAnAppWithAnUpdatedVersionOfTheSameBuildpack(CopyBrats)
 	bratshelper.StagingWithBuildpackThatSetsEOL("php", CopyBrats)
 	bratshelper.StagingWithADepThatIsNotTheLatest("php", CopyBrats)
-	bratshelper.StagingWithCustomBuildpackWithCredentialsInDependencies(CopyBrats)
 	bratshelper.DeployAppWithExecutableProfileScript("php", CopyBrats)
 	bratshelper.DeployAnAppWithSensitiveEnvironmentVariables(CopyBrats)
 


### PR DESCRIPTION
- the change in CDN results in these tests failing, because the new CDN config does not support credentials in this way.
- we believe that consumers do not use this feature, as we have not had any reports of this causing failures for consumers.
- if we get reports that consumers cannot download dependencies from the CDN with credentials, and we deem this to be a necessary feature, we can update the CDN config and re-add these tests.
cc @robdimsdale 