### PR TITLE
replace download.run.pivotal.io as it's not available

### DIFF
--- a/extensions/appdynamics/extension.py
+++ b/extensions/appdynamics/extension.py
@@ -50,7 +50,7 @@ class AppDynamicsInstaller(PHPExtensionHelper):
         object is created.
         """
         return {
-                'APPDYNAMICS_HOST': 'download.run.pivotal.io',
+                'APPDYNAMICS_HOST': 'java-buildpack.cloudfoundry.org',
                 'APPDYNAMICS_VERSION': '23.11.0-839',
                 'APPDYNAMICS_PACKAGE': 'appdynamics-{APPDYNAMICS_VERSION}.tar.bz2',
                 'APPDYNAMICS_DOWNLOAD_URL': 'https://{APPDYNAMICS_HOST}/appdynamics-php/{APPDYNAMICS_PACKAGE}'

--- a/manifest.yml
+++ b/manifest.yml
@@ -58,7 +58,7 @@ dependency_deprecation_dates:
 dependencies:
 - name: appdynamics
   version: 23.11.0-839
-  uri: https://download.run.pivotal.io/appdynamics-php/appdynamics-23.11.0-839.tar.bz2
+  uri: https://java-buildpack.cloudfoundry.org/appdynamics-php/appdynamics-23.11.0-839.tar.bz2
   sha256: '04904a9ddc45bab06b80fa6c32671e82d8edfbaecf8dc943720db7b5c790ec8d'
   cf_stacks:
   - cflinuxfs4


### PR DESCRIPTION
replace download.run.pivotal.io -> java-buildpack.cloudfoundry.org They both seem to be pointing to the same bucket.

And, we have been using that domain in ruby-buildpack: https://github.com/cloudfoundry/ruby-buildpack/blob/v1.10.17/manifest.yml#L69
