### PR TITLE
Use https instead of git+ssh for podhmo/python-node-semver submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/php-fig/log
 [submodule "python-vendor/node-semver"]
 	path = python-vendor/node-semver
-	url = git@github.com:podhmo/python-node-semver.git
+	url = https://github.com/podhmo/python-node-semver.git


### PR DESCRIPTION

**Short explanation of the proposed change:**
Use https instead of git+ssh for `podhmo/python-node-semver` git submodule as it can cause problems in certain environments where only retrieval of a git repository via https is allowed.

**Explanation of the use cases your change solves:**
Fix git submodul retrieval in environments where git clone is only allowed through https.

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

