### PR TITLE
 Add multi-tech support to Dynatrace OneAgent integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/php-fig/log
 [submodule "python-vendor/node-semver"]
 	path = python-vendor/node-semver
-	url = git@github.com:podhmo/python-node-semver.git
+	url = https://github.com/podhmo/python-node-semver.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/php-fig/log
 [submodule "python-vendor/node-semver"]
 	path = python-vendor/node-semver
-	url = https://github.com/podhmo/python-node-semver.git
+	url = git@github.com:podhmo/python-node-semver.git

--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -128,7 +128,7 @@ class DynatraceInstaller(object):
         url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=php&include=nginx&include=apache'
         if self._ctx['DYNATRACE_ADDTECHNOLOGIES']:
             for code_module in self._ctx['DYNATRACE_ADDTECHNOLOGIES'].split(","):
-                self._log.info(f"Adding {code_module} to OneAgent download...")
+                self._log.info(f"Adding additional code module to download: {code_module}")
                 url = f"{url}&include={code_module}"
         if self._ctx['DYNATRACE_NETWORK_ZONE']:
             self._log.info("Setting DT_NETWORK_ZONE...")

--- a/extensions/dynatrace/extension.py
+++ b/extensions/dynatrace/extension.py
@@ -73,6 +73,7 @@ class DynatraceInstaller(object):
             self._ctx['DYNATRACE_TOKEN'] = detected_services[0].get('apitoken', None)
             self._ctx['DYNATRACE_SKIPERRORS'] = detected_services[0].get('skiperrors', None)
             self._ctx['DYNATRACE_NETWORK_ZONE'] = detected_services[0].get('networkzone', None)
+            self._ctx['DYNATRACE_ADDTECHNOLOGIES'] = detected_services[0].get('addtechnologies', None)
 
             self._convert_api_url()
             self._detected = True
@@ -125,6 +126,10 @@ class DynatraceInstaller(object):
         self.create_folder(os.path.join(self._ctx['BUILD_DIR'], 'dynatrace'))
         installer = self._get_oneagent_installer_path()
         url = self._ctx['DYNATRACE_API_URL'] + '/v1/deployment/installer/agent/unix/paas-sh/latest?bitness=64&include=php&include=nginx&include=apache'
+        if self._ctx['DYNATRACE_ADDTECHNOLOGIES']:
+            for code_module in self._ctx['DYNATRACE_ADDTECHNOLOGIES'].split(","):
+                self._log.info(f"Adding {code_module} to OneAgent download...")
+                url = f"{url}&include={code_module}"
         if self._ctx['DYNATRACE_NETWORK_ZONE']:
             self._log.info("Setting DT_NETWORK_ZONE...")
             url = url + ("&networkZone=%s" % self._ctx['DYNATRACE_NETWORK_ZONE'])

--- a/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
+++ b/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
@@ -195,5 +195,17 @@ var _ = Describe("Deploy app with", func() {
 		Expect(app.Stdout.String()).To(ContainSubstring("Fetching updated OneAgent configuration from tenant..."))
 		Expect(app.Stdout.String()).To(ContainSubstring("Finished writing updated OneAgent config back to"))
 	})
+	
+	It("Deploy app with single dynatrace service and additional code modules", func() {
+		serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
+		Expect(RunCf("cups", serviceName, "-p", fmt.Sprintf(`{"apitoken":"secretpaastoken","apiurl":"%s","environmentid":"envid", "networkzone":"testzone", "addtechnologies":"go,nodejs"}`, dynatraceAPIURI))).To(Succeed())
+		Expect(RunCf("bind-service", app.Name, serviceName)).To(Succeed())
+		Expect(RunCf("start", app.Name)).To(Succeed())
+		ConfirmRunning(app)
+
+		Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
+		Expect(app.Stdout.String()).To(ContainSubstring("Adding additional code module to download: go"))
+		Expect(app.Stdout.String()).To(ContainSubstring("Adding additional code module to download: nodejs"))
+	})
 
 })

--- a/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
+++ b/src/php/integration/deploy_a_php_app_with_dynatrace_test.go
@@ -184,9 +184,10 @@ var _ = Describe("Deploy app with", func() {
 		Expect(app.Stdout.String()).To(ContainSubstring("Setting DT_NETWORK_ZONE..."))
 	})
 
-	It("Deploy app with single dynatrace service and check for config update", func() {
+	It("Deploy app with single dynatrace service and check for config update and additional code modules", func() {
 		serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
 		Expect(RunCf("cups", serviceName, "-p", fmt.Sprintf(`{"apitoken":"secretpaastoken","apiurl":"%s","environmentid":"envid", "networkzone":"testzone"}`, dynatraceAPIURI))).To(Succeed())
+		Expect(RunCf("cups", serviceName, "-p", fmt.Sprintf(`{"apitoken":"secretpaastoken","apiurl":"%s","environmentid":"envid", "networkzone":"testzone", "addtechnologies":"go,nodejs"}`, dynatraceAPIURI))).To(Succeed())
 		Expect(RunCf("bind-service", app.Name, serviceName)).To(Succeed())
 		Expect(RunCf("start", app.Name)).To(Succeed())
 		ConfirmRunning(app)
@@ -194,18 +195,7 @@ var _ = Describe("Deploy app with", func() {
 		Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
 		Expect(app.Stdout.String()).To(ContainSubstring("Fetching updated OneAgent configuration from tenant..."))
 		Expect(app.Stdout.String()).To(ContainSubstring("Finished writing updated OneAgent config back to"))
-	})
-	
-	It("Deploy app with single dynatrace service and additional code modules", func() {
-		serviceName := "dynatrace-" + cutlass.RandStringRunes(20) + "-service"
-		Expect(RunCf("cups", serviceName, "-p", fmt.Sprintf(`{"apitoken":"secretpaastoken","apiurl":"%s","environmentid":"envid", "networkzone":"testzone", "addtechnologies":"go,nodejs"}`, dynatraceAPIURI))).To(Succeed())
-		Expect(RunCf("bind-service", app.Name, serviceName)).To(Succeed())
-		Expect(RunCf("start", app.Name)).To(Succeed())
-		ConfirmRunning(app)
-
-		Expect(app.ConfirmBuildpack(buildpackVersion)).To(Succeed())
 		Expect(app.Stdout.String()).To(ContainSubstring("Adding additional code module to download: go"))
 		Expect(app.Stdout.String()).To(ContainSubstring("Adding additional code module to download: nodejs"))
 	})
-
 })


### PR DESCRIPTION
* A short explanation of the proposed change:
This adds suport for a new, optional, configuration property named "addtechnologies" to Dynatrace deployment scenarios. 

* An explanation of the use cases your change solves
This is required to configure additional code-modules for the OneAgent in multi-buildpack and sidecars deployments

* [x] I have viewed signed and have submitted the Contributor License Agreement

* [x] I have made this pull request to the `develop` branch

* [x] I have added an integration test
