### PR TITLE
Add the ability to use TLS to the redis-session extension

### DIFF
--- a/extensions/sessions/extension.py
+++ b/extensions/sessions/extension.py
@@ -48,7 +48,13 @@ class RedisSetup(BaseSetup):
         BaseSetup.__init__(self, ctx, info)
 
     def session_save_path(self):
-        return "tcp://%s:%s?auth=%s" % (
+        uri = self.creds.get('uri', '')
+        if uri.startswith('rediss://'):
+            scheme = 'tls'
+        else:
+            scheme = 'tcp'
+        return "%s://%s:%s?auth=%s" % (
+            scheme,
             self.creds.get('hostname',
                            self.creds.get('host', 'not-found')),
             self.creds.get('port', 'not-found'),


### PR DESCRIPTION
Hello,
PHP buildpack does not seem to support the automatic setting of php ini `session_save_path` variable for redis-sessions services with TLS.
`extensions/sessions/extension.py` only handles the 'tcp:' scheme.
```python
    def session_save_path(self):
        return "tcp://%s:%s?auth=%s" % (
            self.creds.get('hostname',
                           self.creds.get('host', 'not-found')),
            self.creds.get('port', 'not-found'),
            self.creds.get('password', ''))
```
To use TLS, the [Redis 'uri' specification](https://github.com/redis/redis-specifications/blob/master/uri/rediss.txt) indicates that the `‘uri’` parameter could be set with scheme `‘rediss://’` instead of `‘redis://’`.
This `'uri'` parameter could be initialized in the json binding credentials configuration provided by the service broker.
Here's a proposal PR for managing redis-session with TLS

* [ ] I have viewed signed and have submitted the Contributor License Agreement
Go an error at link [Individual CLA](http://cloudfoundry.org/pdfs/CFF_Individual_CLA.pdf) : Error 404 Not Found  :worried:
* [x] I have made this pull request to the `master` branch

* [ ] I have added an integration test
