### PR TITLE
Fix missing libhashkit.so in PHP 8.2.30 and 8.3.30 cflinuxfs5 artifacts

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -620,8 +620,8 @@ dependencies:
     version: 
 - name: php
   version: 8.2.30
-  uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.2.30_linux_x64_cflinuxfs5_3d17decc.tgz
-  sha256: 3d17decc998ecda6f9df19b950dc08c8179251b9fecc0d230bb1c7b9aeb8418a
+  uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.2.30_linux_x64_cflinuxfs5_41e17477.tgz
+  sha256: 41e174771acf804bd7cae041dbf750453405bb9df18d3443b1d5cc2ac3897b92
   cf_stacks:
   - cflinuxfs5
   source: https://php.net/distributions/php-8.2.30.tar.gz
@@ -994,8 +994,8 @@ dependencies:
     version: 
 - name: php
   version: 8.3.30
-  uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.3.30_linux_x64_cflinuxfs5_44e09712.tgz
-  sha256: 44e09712e8d473117929aebb882fcb259fa309377ff50137dd63bf9ecc3eda82
+  uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.3.30_linux_x64_cflinuxfs5_931fc6a2.tgz
+  sha256: 931fc6a27ef9ba4e65e7d3e1e671243a41d4d0708e8db1e8dc8017e6b639a810
   cf_stacks:
   - cflinuxfs5
   source: https://php.net/distributions/php-8.3.30.tar.gz


### PR DESCRIPTION
On Ubuntu 24.04 (cflinuxfs5), libmemcached was split: libmemcached.so.11 now dynamically links against libhashkit.so.2 (shipped as the separate libhashkit2t64 package). On Ubuntu 22.04 (cflinuxfs4) libhashkit was statically linked, so this dependency was invisible.

setupTar() copied libmemcached.so* but omitted libhashkit.so*, causing memcached.so to fail at runtime:

  PHP Startup: Unable to load dynamic library 'memcached.so'
  (libhashkit.so.2: cannot open shared object file: No such file or directory)

Both cflinuxfs5 artifacts were manually repacked with libhashkit.so.2.0.0 and relative symlinks added to lib/. 
 - php_8.2.30_linux_x64_cflinuxfs5_41e17477.tgz — repacked with libhashkit.so.2.0.0 + relative symlinks
 - php_8.3.30_linux_x64_cflinuxfs5_931fc6a2.tgz — same fix
 - both uploaded to S3 and manifest updated

The root fix is in binary-builder [PR #101](https://github.com/cloudfoundry/binary-builder/pull/101) (merged) - future PHP builds will include libhashkit automatically.
