### PR TITLE
Use master branch for git URL buildpack test

### DIFF
--- a/src/php/integration/default_test.go
+++ b/src/php/integration/default_test.go
@@ -94,7 +94,7 @@ func testDefault(platform switchblade.Platform, fixtures string) func(*testing.T
 				}
 
 				deployment, logs, err := platform.Deploy.
-					WithBuildpacks("https://github.com/cloudfoundry/php-buildpack.git#fix-rewrite-binary-compilation").
+					WithBuildpacks("https://github.com/cloudfoundry/php-buildpack.git#master").
 					WithEnv(map[string]string{
 						"BP_DEBUG": "1",
 					}).


### PR DESCRIPTION
## Fix git URL buildpack test for cflinuxfs5

The `fix-rewrite-binary-compilation` branch used in the CF integration test does not have cflinuxfs5 in its manifest, causing staging to fail with `Unsupported stack` when the test runs on cflinuxfs5.

Changed to `master` which always has current stack support. The test purpose (verify git URL buildpack deploys without release YAML pollution) is not specific to that branch.