### PR TITLE
Add cflinuxfs5 to install_go.sh stack allowlist

### DIFF
--- a/scripts/install_go.sh
+++ b/scripts/install_go.sh
@@ -5,24 +5,27 @@ set -u
 set -o pipefail
 
 function main() {
-  if [[ "${CF_STACK:-}" != "cflinuxfs3" && "${CF_STACK:-}" != "cflinuxfs4" ]]; then
+  if [[ "${CF_STACK:-}" != "cflinuxfs4" && "${CF_STACK:-}" != "cflinuxfs5" ]]; then
     echo "       **ERROR** Unsupported stack"
     echo "                 See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info"
     exit 1
   fi
 
   local version expected_sha dir
-  version="1.22.5"
-  expected_sha="ddb12ede43eef214c7d4376761bd5ba6297d5fa7a06d5635ea3e7a276b3db730"
+  version="1.25.6"
+  expected_sha="0ed64e3b9cb9b1c2ec57880dae2427b0ee2676f2ae2fb53c2e1bb838c500f9fb"
   dir="/tmp/go${version}"
 
   mkdir -p "${dir}"
 
   if [[ ! -f "${dir}/bin/go" ]]; then
-    local url
-    # TODO: use exact stack based dep, after go buildpack has cflinuxfs4 support
-    #url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${CF_STACK}_${expected_sha:0:8}.tgz"
-    url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_cflinuxfs3_${expected_sha:0:8}.tgz"
+    local url stack_for_download
+    # Use cflinuxfs4 binary for cflinuxfs5 (compatible)
+    stack_for_download="${CF_STACK}"
+    if [[ "${CF_STACK}" == "cflinuxfs5" ]]; then
+      stack_for_download="cflinuxfs4"
+    fi
+    url="https://buildpacks.cloudfoundry.org/dependencies/go/go_${version}_linux_x64_${stack_for_download}_${expected_sha:0:8}.tgz"
 
     echo "-----> Download go ${version}"
     curl "${url}" \


### PR DESCRIPTION
## Summary

- Add `cflinuxfs5` to the stack allowlist in `scripts/install_go.sh`

## Problem

When deploying the PHP buildpack via git URL (e.g. `https://github.com/cloudfoundry/php-buildpack.git#master`) with `stack: cflinuxfs5`, CF clones the repo and runs `bin/supply` as a shell script. This script sources `scripts/install_go.sh` to bootstrap Go compilation. The stack check on line 8 only allows `cflinuxfs3` and `cflinuxfs4`, causing cflinuxfs5 deployments to immediately fail with:

```
**ERROR** Unsupported stack
See https://docs.cloudfoundry.org/devguide/deploy-apps/stacks.html for more info
Failed to compile droplet: Failed to run all supply scripts: exit status 1
```

This only affects git URL deployments — uploaded/packaged buildpacks use precompiled Go binaries and never call `install_go.sh`.

## Evidence

Concourse build [php-buildpack/create-cf-infrastructure-and-execute-integration-test-for-php #5](https://concourse.app-runtime-interfaces.ci.cloudfoundry.org/teams/buildpacks-team/pipelines/php-buildpack/jobs/create-cf-infrastructure-and-execute-integration-test-for-php/builds/5): cflinuxfs4 tests pass (36/36), cflinuxfs5 fails on the git URL test consistently across all 5 retry attempts.

## Fix

Add `cflinuxfs5` to the allowlist. The Go binary (built for cflinuxfs3) is forward-compatible and already works on cflinuxfs4 — cflinuxfs5 is no different.