### PR TITLE
Remove cf-helper-php from test fixtures to fix Composer 2.9.8 failures

### DIFF
--- a/fixtures/with_amqp/composer.json
+++ b/fixtures/with_amqp/composer.json
@@ -1,6 +1,5 @@
 {
     "require": {
-        "ext-amqp": "*",
-        "cloudfoundry-community/cf-helper-php": "1.6.*"
+        "ext-amqp": "*"
     }
 }

--- a/fixtures/with_phpredis/composer.json
+++ b/fixtures/with_phpredis/composer.json
@@ -1,7 +1,6 @@
 {
     "require": {
         "ext-redis": "*",
-        "ext-igbinary": "*",
-        "cloudfoundry-community/cf-helper-php": "1.6.*"
+        "ext-igbinary": "*"
     }
 }

--- a/fixtures/with_phpredis/index.php
+++ b/fixtures/with_phpredis/index.php
@@ -5,33 +5,13 @@
 <body>
 <h1>This page initiates a Redis connection and displays Redis info via the phpredis client.</h1>
 <?php
-  require_once 'vendor/autoload.php';
-  use CfCommunity\CfHelper\CfHelper;
-  $cfHelper = CfHelper::getInstance();
-
-  # Try to fetch Redis VCAP_SERVICES values
-  $serviceManager = $cfHelper->getServiceManager();
-  $redisService = $serviceManager->getService('.*redis.*');
-
-  $defaultUrl = "localhost";
-  $defaulPort = 6379;
-  $defaulPassword = "password";
-
-  # Prevent PHP Errors if no service is bound
-  if (is_null($redisService)){
-    $redisUrl = $defaultUrl;
-    $redisPort = $defaulPort;
-    $redisPassword = $defaulPassword;
-  }
-  else {
-    $redisUrl = $redisService->getValue('hostname');
-    $redisPort = $redisService->getValue('port');
-    $redisPassword = $redisService->getValue('password');
-  }
+  $redisUrl = "localhost";
+  $redisPort = 6379;
+  $redisPassword = "password";
 
   print "<p>RedisUrl: $redisUrl</p>";
   print "<p>RedisPort: $redisPort</p>";
-  print "<p>RedisUrl: redacted</p>";
+  print "<p>RedisPassword: redacted</p>";
 
   # Establish Redis connection and authenticate
   $redis = new Redis();


### PR DESCRIPTION
## Summary
- Remove unmaintained `cloudfoundry-community/cf-helper-php 1.6.*` from `with_phpredis` and `with_amqp` test fixtures
- Simplify `with_phpredis/index.php` to connect directly to localhost instead of using CfHelper VCAP_SERVICES parsing

## Problem
Composer 2.9.8 introduced `block-insecure` audit behavior that blocks packages with known security advisories by default. The `cf-helper-php 1.6.*` dependency transitively requires:
- `filp/whoops ~1.1` (advisory `PKSA-vbfj-ghxh-xgb7`)
- `symfony/yaml ~2.5` (advisories `PKSA-v5yj-8nmz-sk2q`, `PKSA-ft77-7h5f-p3r6`, `PKSA-b14r-zh1d-vdrc`)

This causes `composer install` to fail during staging, breaking the `app_with_phpredis_module` and `app_with_amqp_module` switchblade tests.

## Why removal instead of upgrade
- `cf-helper-php` is effectively abandoned (last release: Jan 2020)
- Neither test verifies `cf-helper-php` functionality — they only check that PHP extensions (`ext-redis`, `ext-amqp`, `ext-igbinary`) load correctly
- The `with_amqp` fixture never imported cf-helper-php in its code at all
- The `with_phpredis` fixture used CfHelper to parse VCAP_SERVICES for Redis connection info, but always falls back to localhost defaults since no Redis service is bound in tests