### PR TITLE
fix: COMPOSER_INSTALL_OPTIONS from options.json silently ignored (#1265)

### DIFF
--- a/fixtures/composer_install_options/.bp-config/options.json
+++ b/fixtures/composer_install_options/.bp-config/options.json
@@ -1,0 +1,3 @@
+{
+    "COMPOSER_INSTALL_OPTIONS": ["--dev"]
+}

--- a/fixtures/composer_install_options/composer.json
+++ b/fixtures/composer_install_options/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "cloudfoundry/composer_install_options_test",
+    "require": {
+        "php": ">=8.1"
+    },
+    "require-dev": {
+        "psr/log": "^3.0"
+    }
+}

--- a/fixtures/composer_install_options/composer.lock
+++ b/fixtures/composer_install_options/composer.lock
@@ -1,0 +1,71 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.1"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/fixtures/composer_install_options/htdocs/index.php
+++ b/fixtures/composer_install_options/htdocs/index.php
@@ -1,0 +1,11 @@
+<?php
+require '../lib/vendor/autoload.php';
+
+// psr/log is a require-dev dependency.
+// If COMPOSER_INSTALL_OPTIONS: ["--dev"] is honoured, this class exists.
+if (interface_exists('Psr\Log\LoggerInterface')) {
+    echo "dev dependencies installed";
+} else {
+    http_response_code(500);
+    echo "dev dependencies missing";
+}

--- a/src/php/integration/composer_test.go
+++ b/src/php/integration/composer_test.go
@@ -117,6 +117,28 @@ func testComposer(platform switchblade.Platform, fixtures string) func(*testing.
 			})
 		})
 
+		// Regression test for https://github.com/cloudfoundry/php-buildpack/issues/1265
+		// COMPOSER_INSTALL_OPTIONS in options.json was silently ignored in v5 because
+		// supply.go never wrote the parsed value into the extension Context.Data map.
+		// As a result, composer always ran with the hardcoded default ["--no-interaction",
+		// "--no-dev"], making it impossible to install dev dependencies via options.json.
+		context("composer app with COMPOSER_INSTALL_OPTIONS set to --dev in options.json", func() {
+			it("installs dev dependencies (issue #1265)", func() {
+				deployment, logs, err := platform.Deploy.
+					WithEnv(map[string]string{
+						"COMPOSER_GITHUB_OAUTH_TOKEN": os.Getenv("COMPOSER_GITHUB_OAUTH_TOKEN"),
+					}).
+					Execute(name, filepath.Join(fixtures, "composer_install_options"))
+				Expect(err).NotTo(HaveOccurred(), logs.String)
+
+				// Staging log must NOT contain --no-dev, confirming the user option overrides the default
+				Expect(logs.String()).NotTo(ContainSubstring("--no-dev"))
+
+				// The running app confirms psr/log (a require-dev package) was installed
+				Eventually(deployment).Should(Serve(ContainSubstring("dev dependencies installed")))
+			})
+		})
+
 		if !settings.Cached {
 			context("deployed with invalid COMPOSER_GITHUB_OAUTH_TOKEN", func() {
 				it("logs warning", func() {

--- a/src/php/supply/supply.go
+++ b/src/php/supply/supply.go
@@ -201,6 +201,7 @@ func (s *Supplier) createExtensionContext() (*extensions.Context, error) {
 	// Set additional options
 	ctx.Set("ADMIN_EMAIL", s.Options.AdminEmail)
 	ctx.Set("COMPOSER_VENDOR_DIR", s.Options.ComposerVendorDir)
+	ctx.Set("COMPOSER_INSTALL_OPTIONS", s.Options.ComposerInstallOptions)
 
 	// Set dynamic PHP version variables
 	for key, version := range s.Options.PHPVersions {


### PR DESCRIPTION
## Summary

- `COMPOSER_INSTALL_OPTIONS` set in `.bp-config/options.json` was silently ignored in v5
- The composer extension always fell back to the hardcoded default `["--no-interaction", "--no-dev"]`, making it impossible to install dev dependencies via configuration
- Adds a regression integration test to prevent recurrence

## Root Cause

`supply.go` parses `COMPOSER_INSTALL_OPTIONS` from `options.json` into `s.Options.ComposerInstallOptions` correctly, but never wrote it into the extension `Context.Data` map. The composer extension reads it back via `ctx.GetStringSlice("COMPOSER_INSTALL_OPTIONS")`, which returned `nil`, so the hardcoded default was always used.

## Fix

One line added in `supply.go` alongside the other options already written to the context:

```go
ctx.Set("COMPOSER_INSTALL_OPTIONS", s.Options.ComposerInstallOptions)
```

## Testing

Added an integration test (`composer_test.go`) with a fixture app that:
- Sets `"COMPOSER_INSTALL_OPTIONS": ["--dev"]` in `.bp-config/options.json`
- Has `psr/log ^3.0` as a `require-dev` dependency only
- Serves a response confirming the dev package is accessible at runtime

The test asserts:
1. Staging logs do **not** contain `--no-dev` (confirming the user option overrides the default)
2. The running app responds with `"dev dependencies installed"`

Fixes #1265