### PR TITLE
fix: quote go test flags in integration.sh

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -147,12 +147,12 @@ function specs::run() {
       -mod vendor \
       -v \
         "${src}/integration" \
-         ${cached_flag} \
-         ${platform_flag} \
-         ${token_flag} \
-         ${stack_flag} \
-         ${serial_flag} \
-         ${keep_failed_flag}
+         "${cached_flag}" \
+         "${platform_flag}" \
+         "${token_flag}" \
+         "${stack_flag}" \
+         "${serial_flag}" \
+         "${keep_failed_flag}"
 }
 
 function buildpack::package() {


### PR DESCRIPTION
## Summary

- Quote all `go test` flag variables in `scripts/integration.sh` to align with the style used in `go-buildpack` and `ruby-buildpack`
- Unquoted variables work in most cases but are inconsistent with the rest of the buildpack ecosystem