### PR TITLE
Add php 8.3.31, remove php 8.3.21, fix yaf fixtures and deprecation date

### DIFF
--- a/fixtures/php_all_modules/.bp-config/options.json
+++ b/fixtures/php_all_modules/.bp-config/options.json
@@ -61,6 +61,7 @@
     "tideways_xhprof",
     "tidy",
     "xsl",
+    "yaf",
     "yaml",
     "zip",
     "zlib",

--- a/fixtures/php_all_modules_composer/composer.json
+++ b/fixtures/php_all_modules_composer/composer.json
@@ -56,6 +56,7 @@
         "ext-tideways_xhprof": "*",
         "ext-tidy": "*",
         "ext-xsl": "*",
+        "ext-yaf": "*",
         "ext-yaml": "*",
         "ext-zip": "*",
         "ext-zlib": "*",

--- a/manifest.yml
+++ b/manifest.yml
@@ -35,7 +35,7 @@ dependency_deprecation_dates:
   match: 8.2.\d+
 - version_line: 8.3.x
   name: php
-  date: 2025-12-31
+  date: 2026-11-23
   link: http://php.net/supported-versions.php
   match: 8.3.\d+
 - version_line: 8.4.x

--- a/manifest.yml
+++ b/manifest.yml
@@ -35,7 +35,7 @@ dependency_deprecation_dates:
   match: 8.2.\d+
 - version_line: 8.3.x
   name: php
-  date: 2026-11-23
+  date: 2025-12-31
   link: http://php.net/supported-versions.php
   match: 8.3.\d+
 - version_line: 8.4.x
@@ -753,130 +753,6 @@ dependencies:
   - name: zlib
     version: 
 - name: php
-  version: 8.3.21
-  uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.3.21_linux_x64_cflinuxfs4_699bf9bc.tgz
-  sha256: 699bf9bc863a8d0707fbc422d0351cdd7b1bc865b067ecc146838589c06105e7
-  cf_stacks:
-  - cflinuxfs4
-  source: https://php.net/distributions/php-8.3.21.tar.gz
-  source_sha256: e7f1748c1fa3d2bf8ef2e00508bd62325ba68c3b830b253bc561225a9ba5457d
-  dependencies:
-  - name: amqp
-    version: 2.1.2
-  - name: apcu
-    version: 5.1.23
-  - name: bz2
-    version: 
-  - name: curl
-    version: 
-  - name: dba
-    version: 
-  - name: enchant
-  - name: exif
-    version: 
-  - name: fileinfo
-    version: 
-  - name: ftp
-    version: 
-  - name: gd
-  - name: gettext
-    version: 
-  - name: gmp
-    version: 
-  - name: igbinary
-    version: 3.2.15
-  - name: imagick
-    version: 3.7.0
-  - name: imap
-    version: 
-  - name: ldap
-    version: 
-  - name: lzf
-    version: 
-  - name: mailparse
-    version: 3.1.6
-  - name: maxminddb
-    version: 1.11.1
-  - name: mbstring
-    version: 
-  - name: memcached
-    version: 3.2.0
-  - name: mongodb
-    version: 1.18.1
-  - name: msgpack
-    version: 2.2.0
-  - name: mysqli
-    version: 
-  - name: oauth
-    version: 2.0.7
-  - name: opcache
-    version: 
-  - name: openssl
-    version: 
-  - name: pcntl
-    version: 
-  - name: pdo
-    version: 
-  - name: pdo_firebird
-  - name: pdo_mysql
-    version: 
-  - name: pdo_odbc
-  - name: pdo_pgsql
-    version: 
-  - name: pdo_sqlite
-    version: 
-  - name: pdo_sqlsrv
-    version: 5.12.0
-  - name: pgsql
-    version: 
-  - name: phalcon
-    version: 5.6.2
-  - name: phpiredis
-    version: 1.0.1
-  - name: pspell
-    version: 
-  - name: psr
-    version: 1.2.0
-  - name: rdkafka
-    version: 6.0.3
-  - name: readline
-  - name: redis
-    version: 6.0.2
-  - name: shmop
-    version: 
-  - name: snmp
-  - name: soap
-    version: 
-  - name: sockets
-    version: 
-  - name: sodium
-  - name: solr
-    version: 2.7.0
-  - name: sqlsrv
-    version: 5.12.0
-  - name: ssh2
-    version: 1.4.1
-  - name: stomp
-    version: 2.0.3
-  - name: sysvmsg
-    version: 
-  - name: sysvsem
-    version: 
-  - name: sysvshm
-    version: 
-  - name: tideways_xhprof
-    version: 5.0.4
-  - name: tidy
-  - name: xdebug
-    version: 3.3.2
-  - name: xsl
-    version: 
-  - name: yaml
-    version: 2.2.3
-  - name: zip
-  - name: zlib
-    version: 
-- name: php
   version: 8.3.30
   uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.3.30_linux_x64_cflinuxfs4_bac0bfc1.tgz
   sha256: bac0bfc18b86bc300a172742b09f170057f730614f7e0b90b812258453f43929
@@ -1123,6 +999,134 @@ dependencies:
     version: 3.3.2
   - name: xsl
     version: 
+  - name: yaml
+    version: 2.2.3
+  - name: zip
+  - name: zlib
+    version: 
+- name: php
+  version: 8.3.31
+  uri: https://buildpacks.cloudfoundry.org/dependencies/php/php_8.3.31_linux_x64_cflinuxfs4_6f5a35e7.tgz
+  sha256: 6f5a35e755045020e915c25de4ed9711454545c533ea02af751d7c342599cdaf
+  cf_stacks:
+  - cflinuxfs4
+  source: https://php.net/distributions/php-8.3.31.tar.gz
+  source_sha256: 4e7baaf0a690e954a20e7ced3dd633ce8cb8094e2b6b612a55e703ecbbdcbf4f
+  dependencies:
+  - name: amqp
+    version: 2.1.2
+  - name: apcu
+    version: 5.1.28
+  - name: bz2
+    version: 
+  - name: curl
+    version: 
+  - name: dba
+    version: 
+  - name: enchant
+  - name: exif
+    version: 
+  - name: fileinfo
+    version: 
+  - name: ftp
+    version: 
+  - name: gd
+  - name: gettext
+    version: 
+  - name: gmp
+    version: 
+  - name: igbinary
+    version: 3.2.15
+  - name: imagick
+    version: 3.7.0
+  - name: imap
+    version: 
+  - name: ioncube
+    version: 14.0.0
+  - name: ldap
+    version: 
+  - name: lzf
+    version: 
+  - name: mailparse
+    version: 3.1.6
+  - name: maxminddb
+    version: 1.11.1
+  - name: mbstring
+    version: 
+  - name: memcached
+    version: 3.2.0
+  - name: mongodb
+    version: 1.18.1
+  - name: msgpack
+    version: 2.2.0
+  - name: mysqli
+    version: 
+  - name: oauth
+    version: 2.0.7
+  - name: opcache
+    version: 
+  - name: openssl
+    version: 
+  - name: pcntl
+    version: 
+  - name: pdo
+    version: 
+  - name: pdo_firebird
+  - name: pdo_mysql
+    version: 
+  - name: pdo_odbc
+  - name: pdo_pgsql
+    version: 
+  - name: pdo_sqlite
+    version: 
+  - name: pdo_sqlsrv
+    version: 5.12.0
+  - name: pgsql
+    version: 
+  - name: phalcon
+    version: 5.6.2
+  - name: phpiredis
+    version: 1.0.1
+  - name: pspell
+    version: 
+  - name: psr
+    version: 1.2.0
+  - name: rdkafka
+    version: 6.0.3
+  - name: readline
+  - name: redis
+    version: 6.0.2
+  - name: shmop
+    version: 
+  - name: snmp
+  - name: soap
+    version: 
+  - name: sockets
+    version: 
+  - name: sodium
+  - name: solr
+    version: 2.7.0
+  - name: sqlsrv
+    version: 5.12.0
+  - name: ssh2
+    version: 1.4.1
+  - name: stomp
+    version: 2.0.3
+  - name: sysvmsg
+    version: 
+  - name: sysvsem
+    version: 
+  - name: sysvshm
+    version: 
+  - name: tideways_xhprof
+    version: 5.0.4
+  - name: tidy
+  - name: xdebug
+    version: 3.3.2
+  - name: xsl
+    version: 
+  - name: yaf
+    version: 3.3.7
   - name: yaml
     version: 2.2.3
   - name: zip


### PR DESCRIPTION
## Summary

- Adds PHP 8.3.31 and removes PHP 8.3.21 for cflinuxfs4 stack (original change from PR #1268)
- Adds `yaf` extension to `php_all_modules` and `php_all_modules_composer` test fixtures so integration tests pass with the new default PHP 8.3.31 (which includes yaf 3.3.7 as a sub-dependency)
- Fixes PHP 8.3.x `dependency_deprecation_dates` entry from `2025-12-31` back to `2026-11-23`
- Rebased onto master (picks up PHP 8.2.31 addition and cf-helper-php removal from recent merged PRs)

Fixes integration test failures that would have occurred with PR #1268 as originally submitted.