### PR TITLE
Add httpd 2.4.67 for stack(s) cflinuxfs5

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -68,13 +68,13 @@ dependencies:
   source: https://github.com/composer/composer/releases/download/2.10.0/composer.phar
   source_sha256: a346538851988ead111d11e3cbd7d372eeba44abd0af412e09890d3c21ea6c31
 - name: httpd
-  version: 2.4.66
-  uri: https://buildpacks.cloudfoundry.org/dependencies/httpd/httpd_2.4.66_linux_x64_cflinuxfs5_a21e24cb.tgz
-  sha256: a21e24cb92bab61393a9d4381cf7d6d65e50d486d239808b860c84c96fd8e737
+  version: 2.4.67
+  uri: https://buildpacks.cloudfoundry.org/dependencies/httpd/httpd_2.4.67_linux_x64_cflinuxfs5_7e4a72af.tgz
+  sha256: 7e4a72af80eb30439bedd9d3affbe782512b15d7d5698e69a7f07760fb3dd52b
   cf_stacks:
   - cflinuxfs5
-  source: https://dlcdn.apache.org/httpd/httpd-2.4.66.tar.bz2
-  source_sha256: 94d7ff2b42acbb828e870ba29e4cbad48e558a79c623ad3596e4116efcfea25a
+  source: https://dlcdn.apache.org/httpd/httpd-2.4.67.tar.bz2
+  source_sha256: 66cd206637b0d5c446fa7dabe75fe03525da8fb55855876c46288cd88b136aa4
 - name: httpd
   version: 2.4.67
   uri: https://buildpacks.cloudfoundry.org/dependencies/httpd/httpd_2.4.67_linux_x64_cflinuxfs4_bdb43550.tgz


### PR DESCRIPTION
## Summary

- Adds the missing `httpd 2.4.67` dependency entry for `cflinuxfs5`
- Removes the now-outdated `httpd 2.4.66` entry for `cflinuxfs5`

## Root Cause

The releng bot PR that bumped httpd to `2.4.67` was created by the `update-httpd-latest-php` Concourse job before the cflinuxfs5 build artifact was pushed to the `builds` git repo (race condition in the dependency-builds pipeline). This left the manifest in a broken state:
- `default_versions` httpd bumped to `2.4.67`
- `httpd 2.4.67` entry only present for `cflinuxfs4`
- `httpd 2.4.66` still present for `cflinuxfs5`

This caused `buildpack-packager` to fail with:
```
No matching default dependency httpd for stack cflinuxfs5
```

## Fix

Manually adds the cflinuxfs5 entry using the binary that was already built and uploaded to S3:
- **URI**: `https://buildpacks.cloudfoundry.org/dependencies/httpd/httpd_2.4.67_linux_x64_cflinuxfs5_7e4a72af.tgz`
- **sha256**: `7e4a72af80eb30439bedd9d3affbe782512b15d7d5698e69a7f07760fb3dd52b`

Fixes the failing CI job: `php-buildpack/specs-switchblade-docker-cflinuxfs5`