### PR TITLE
Test: Reorder integration tests to diagnose position-dependent failure

### DIFF
--- a/src/php/integration/init_test.go
+++ b/src/php/integration/init_test.go
@@ -70,8 +70,9 @@ func TestIntegration(t *testing.T) {
 	// Expect(err).NotTo(HaveOccurred())
 
 	suite := spec.New("integration", spec.Report(report.Terminal{}), spec.Parallel())
-	suite("Default", testDefault(platform, fixtures))
+	// Reordered: Moved "Default" to second position to test if failure is position-dependent
 	suite("Modules", testModules(platform, fixtures))
+	suite("Default", testDefault(platform, fixtures))
 	suite("Composer", testComposer(platform, fixtures))
 	suite("WebServers", testWebServers(platform, fixtures))
 	suite("AppFrameworks", testAppFrameworks(platform, fixtures))


### PR DESCRIPTION
Move 'Default' test to second position to determine if the consistent failure is related to being the first test to execute or specific to the test itself.

If a different test now fails first, it indicates a timing/resource issue. If 'Default' still fails, it's something specific about that test fixture.

Related to integration test failure with HTTP 500 error on php.buildpacks.ci.cloudfoundry.org environment.