### PR TITLE
Read php.ini from the dependency directory in the sessions extension

### DIFF
--- a/src/php/extensions/extension.go
+++ b/src/php/extensions/extension.go
@@ -447,10 +447,15 @@ type PHPConfigHelper struct {
 
 // NewPHPConfigHelper creates a new PHP config helper
 func NewPHPConfigHelper(ctx *Context) *PHPConfigHelper {
+	// PHP is installed into the dependency directory, and ctx.BuildDir is empty
+	// during staging because BUILD_DIR is not exported to the buildpack. The
+	// supply phase records the real path under the DEPS_DIR key instead.
+	phpEtcDir := filepath.Join(ctx.GetString("DEPS_DIR"), "php", "etc")
+
 	return &PHPConfigHelper{
 		ctx:        ctx,
-		phpIniPath: filepath.Join(ctx.BuildDir, "php", "etc", "php.ini"),
-		phpFpmPath: filepath.Join(ctx.BuildDir, "php", "etc", "php-fpm.conf"),
+		phpIniPath: filepath.Join(phpEtcDir, "php.ini"),
+		phpFpmPath: filepath.Join(phpEtcDir, "php-fpm.conf"),
 	}
 }
 

--- a/src/php/extensions/sessions/sessions_test.go
+++ b/src/php/extensions/sessions/sessions_test.go
@@ -12,10 +12,10 @@ import (
 
 var _ = Describe("SessionsExtension", func() {
 	var (
-		ext      *sessions.SessionsExtension
-		ctx      *extensions.Context
-		err      error
-		buildDir string
+		ext     *sessions.SessionsExtension
+		ctx     *extensions.Context
+		err     error
+		depsDir string
 	)
 
 	BeforeEach(func() {
@@ -23,18 +23,18 @@ var _ = Describe("SessionsExtension", func() {
 		ctx, err = extensions.NewContext()
 		Expect(err).NotTo(HaveOccurred())
 
-		// Create temp build directory for file operations
-		buildDir, err = os.MkdirTemp("", "sessions-test")
+		// PHP is installed into the dependency directory, which is where the
+		// supply phase records DEPS_DIR and writes php.ini.
+		depsDir, err = os.MkdirTemp("", "sessions-test")
 		Expect(err).NotTo(HaveOccurred())
 
-		// Set BuildDir directly on the struct field (not via Set() which uses Data map)
-		ctx.BuildDir = buildDir
+		ctx.Set("DEPS_DIR", depsDir)
 		ctx.Set("BP_DIR", "/tmp/bp")
 	})
 
 	AfterEach(func() {
-		if buildDir != "" {
-			os.RemoveAll(buildDir)
+		if depsDir != "" {
+			os.RemoveAll(depsDir)
 		}
 	})
 
@@ -213,7 +213,7 @@ var _ = Describe("SessionsExtension", func() {
 		var phpDir string
 
 		BeforeEach(func() {
-			phpDir = filepath.Join(buildDir, "php")
+			phpDir = filepath.Join(depsDir, "php")
 			err := os.MkdirAll(filepath.Join(phpDir, "etc"), 0755)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Staging fails for any app with a bound Redis or Memcached session service:

```
Running extension Compile phase
**ERROR** Extension compilation failed: extension sessions compile failed: failed to load PHP config: failed to load php.ini: failed to read config file php/etc/php.ini: open php/etc/php.ini: no such file or directory
Failed to compile droplet: Failed to run all supply scripts: exit status 14
```

This is the failure reported in #1291.

**Cause**

`NewPHPConfigHelper` builds its paths from `ctx.BuildDir`:

```go
phpIniPath: filepath.Join(ctx.BuildDir, "php", "etc", "php.ini"),
```

`NewContext` fills that field from `os.Getenv("BUILD_DIR")`, which the lifecycle never exports, so it is empty and the helper opens the relative path `php/etc/php.ini`. `createExtensionContext` does call `ctx.Set("BUILD_DIR", s.Stager.BuildDir())`, but `Set` writes into the `Data` map and does not reach the struct field. Every other extension reads `ctx.GetString("BUILD_DIR")` and is unaffected, which is why only the sessions path breaks.

The build directory is also the wrong base. `installPHP` uses `filepath.Join(s.Stager.DepDir(), "php")`, and `php.ini` is written to `<deps>/<idx>/php/etc/php.ini`. Nothing writes to `<build>/php`.

**Fix**

Resolve `php.ini` and `php-fpm.conf` from `ctx.GetString("DEPS_DIR")`, which the supply phase sets to `s.Stager.DepDir()`.

**Test**

`sessions_test.go` passed only because it assigned `ctx.BuildDir` directly, with a comment noting that `Set()` would not work, and created `php/etc` under the build directory. That layout does not exist at staging time, so the test could not catch this. It now models the dependency directory. All unit tests pass; `src/php/brats` fails identically before and after this change, on a `DeferCleanup` misuse in the vendored `bratshelper`.
